### PR TITLE
remove Suite.ctx field (unused)

### DIFF
--- a/exec/parse_test.go
+++ b/exec/parse_test.go
@@ -51,7 +51,6 @@ func TestSimpleCommand(t *testing.T) {
 	assert.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
-	sc := s.(*scenario.Scenario)
 	expTests := []gdttypes.TestUnit{
 		&gdtexec.Spec{
 			Spec: gdttypes.Spec{
@@ -61,5 +60,5 @@ func TestSimpleCommand(t *testing.T) {
 			Exec: "ls",
 		},
 	}
-	assert.Equal(expTests, sc.Tests)
+	assert.Equal(expTests, s.Tests)
 }

--- a/scenario/from.go
+++ b/scenario/from.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/gdt-dev/gdt/parse"
-	gdttypes "github.com/gdt-dev/gdt/types"
 	"gopkg.in/yaml.v3"
+
+	"github.com/gdt-dev/gdt/parse"
 )
 
 // FromReader parses the supplied io.Reader and returns a Scenario representing
@@ -19,7 +19,7 @@ import (
 func FromReader(
 	r io.Reader,
 	mods ...ScenarioModifier,
-) (gdttypes.Runnable, error) {
+) (*Scenario, error) {
 	contents, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func FromReader(
 func FromBytes(
 	contents []byte,
 	mods ...ScenarioModifier,
-) (gdttypes.Runnable, error) {
+) (*Scenario, error) {
 	s := New(mods...)
 	expanded := parse.ExpandWithFixedDoubleDollar(string(contents))
 	if err := yaml.Unmarshal([]byte(expanded), s); err != nil {

--- a/scenario/parse_test.go
+++ b/scenario/parse_test.go
@@ -45,10 +45,9 @@ func TestNoTests(t *testing.T) {
 	assert.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
-	sc := s.(*scenario.Scenario)
-	assert.Equal("no-tests", sc.Name)
-	assert.Equal(filepath.Join("testdata", "no-tests.yaml"), sc.Path)
-	assert.Equal([]string{"books_api", "books_data"}, sc.Require)
+	assert.Equal("no-tests", s.Name)
+	assert.Equal(filepath.Join("testdata", "no-tests.yaml"), s.Path)
+	assert.Equal([]string{"books_api", "books_data"}, s.Require)
 	assert.Equal(
 		map[string]interface{}{
 			"foo": &fooDefaults{
@@ -61,9 +60,9 @@ func TestNoTests(t *testing.T) {
 			"priorRun":           &priorRunDefaults{},
 			scenario.DefaultsKey: &scenario.Defaults{},
 		},
-		sc.Defaults,
+		s.Defaults,
 	)
-	assert.Empty(sc.Tests)
+	assert.Empty(s.Tests)
 }
 
 func TestFailingPlugin(t *testing.T) {
@@ -145,10 +144,9 @@ func TestKnownSpec(t *testing.T) {
 	assert.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
-	sc := s.(*scenario.Scenario)
-	assert.Equal("foo", sc.Name)
-	assert.Equal(filepath.Join("testdata", "foo.yaml"), sc.Path)
-	assert.Empty(sc.Require)
+	assert.Equal("foo", s.Name)
+	assert.Equal(filepath.Join("testdata", "foo.yaml"), s.Path)
+	assert.Empty(s.Require)
 	assert.Equal(
 		map[string]interface{}{
 			"foo": &fooDefaults{
@@ -161,7 +159,7 @@ func TestKnownSpec(t *testing.T) {
 			"priorRun":           &priorRunDefaults{},
 			scenario.DefaultsKey: &scenario.Defaults{},
 		},
-		sc.Defaults,
+		s.Defaults,
 	)
 	expSpecDefaults := &gdttypes.Defaults{
 		"foo": &fooDefaults{
@@ -192,7 +190,7 @@ func TestKnownSpec(t *testing.T) {
 			Foo: "baz",
 		},
 	}
-	assert.Equal(expTests, sc.Tests)
+	assert.Equal(expTests, s.Tests)
 }
 
 func TestMultipleSpec(t *testing.T) {
@@ -208,9 +206,8 @@ func TestMultipleSpec(t *testing.T) {
 	assert.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
-	sc := s.(*scenario.Scenario)
-	assert.Equal("foo-bar", sc.Name)
-	assert.Equal(filepath.Join("testdata", "foo-bar.yaml"), sc.Path)
+	assert.Equal("foo-bar", s.Name)
+	assert.Equal(filepath.Join("testdata", "foo-bar.yaml"), s.Path)
 	expTests := []gdttypes.TestUnit{
 		&fooSpec{
 			Spec: gdttypes.Spec{
@@ -227,7 +224,7 @@ func TestMultipleSpec(t *testing.T) {
 			Bar: 42,
 		},
 	}
-	assert.Equal(expTests, sc.Tests)
+	assert.Equal(expTests, s.Tests)
 }
 
 func TestEnvExpansion(t *testing.T) {
@@ -247,10 +244,9 @@ func TestEnvExpansion(t *testing.T) {
 	assert.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
-	sc := s.(*scenario.Scenario)
-	assert.Equal("env-expansion", sc.Name)
-	assert.Equal(filepath.Join("testdata", "env-expansion.yaml"), sc.Path)
-	assert.Empty(sc.Require)
+	assert.Equal("env-expansion", s.Name)
+	assert.Equal(filepath.Join("testdata", "env-expansion.yaml"), s.Path)
+	assert.Empty(s.Require)
 	assert.Equal(
 		map[string]interface{}{
 			"foo": &fooDefaults{
@@ -263,7 +259,7 @@ func TestEnvExpansion(t *testing.T) {
 			"priorRun":           &priorRunDefaults{},
 			scenario.DefaultsKey: &scenario.Defaults{},
 		},
-		sc.Defaults,
+		s.Defaults,
 	)
 	expSpecDefaults := &gdttypes.Defaults{
 		"foo": &fooDefaults{
@@ -294,7 +290,7 @@ func TestEnvExpansion(t *testing.T) {
 			Foo: "baz",
 		},
 	}
-	assert.Equal(expTests, sc.Tests)
+	assert.Equal(expTests, s.Tests)
 }
 
 func TestScenarioDefaults(t *testing.T) {
@@ -310,10 +306,9 @@ func TestScenarioDefaults(t *testing.T) {
 	assert.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
-	sc := s.(*scenario.Scenario)
-	assert.Equal("foo-timeout", sc.Name)
-	assert.Equal(filepath.Join("testdata", "foo-timeout.yaml"), sc.Path)
-	assert.Empty(sc.Require)
+	assert.Equal("foo-timeout", s.Name)
+	assert.Equal(filepath.Join("testdata", "foo-timeout.yaml"), s.Path)
+	assert.Empty(s.Require)
 	assert.Equal(
 		map[string]interface{}{
 			"foo":      &fooDefaults{},
@@ -326,7 +321,7 @@ func TestScenarioDefaults(t *testing.T) {
 				},
 			},
 		},
-		sc.Defaults,
+		s.Defaults,
 	)
 	expSpecDefaults := &gdttypes.Defaults{
 		"foo":      &fooDefaults{},
@@ -358,5 +353,5 @@ func TestScenarioDefaults(t *testing.T) {
 			Foo: "baz",
 		},
 	}
-	assert.Equal(expTests, sc.Tests)
+	assert.Equal(expTests, s.Tests)
 }

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -5,19 +5,12 @@
 package suite
 
 import (
-	"context"
-
-	gdttypes "github.com/gdt-dev/gdt/types"
+	"github.com/gdt-dev/gdt/scenario"
 )
 
 // Suite contains zero or more Runnable things, one for each YAML file
 // representing a Scenario in a given directory
 type Suite struct {
-	// ctx stores the context. Yes, I know this is not good practice and that a
-	// context should be passed as the first argument to all methods, but the
-	// `yaml.Unmarshaler` interface does not have a context argument and
-	// there's no other way to pass in necessary information.
-	ctx context.Context
 	// Path is the filepath to the test suite directory.
 	Path string `yaml:"-"`
 	// Name is the short name for the test suite. If empty, defaults to Path.
@@ -34,7 +27,7 @@ type Suite struct {
 	// cases depends on.
 	Require []string `yaml:"require,omitempty"`
 	// Scenarios is a collection of test scenarios in this test suite
-	Scenarios []gdttypes.Runnable `yaml:"-"`
+	Scenarios []*scenario.Scenario `yaml:"-"`
 }
 
 // SuiteModifier sets some value on the test suite
@@ -75,13 +68,6 @@ func WithRequires(require []string) SuiteModifier {
 	}
 }
 
-// WithContext sets a test scenario's context
-func WithContext(ctx context.Context) SuiteModifier {
-	return func(s *Suite) {
-		s.ctx = ctx
-	}
-}
-
 // New returns a new Suite
 func New(mods ...SuiteModifier) *Suite {
 	s := &Suite{}
@@ -92,6 +78,6 @@ func New(mods ...SuiteModifier) *Suite {
 }
 
 // Append appends a runnable test element to the test suite
-func (s *Suite) Append(r gdttypes.Runnable) {
-	s.Scenarios = append(s.Scenarios, r)
+func (s *Suite) Append(sc *scenario.Scenario) {
+	s.Scenarios = append(s.Scenarios, sc)
 }

--- a/types/runnable.go
+++ b/types/runnable.go
@@ -11,8 +11,7 @@ import (
 
 // Runnable represents things that have a Run() method that accepts a Context
 // and a pointer to a testing.T. Example things that implement this interface
-// are `gdtcore.scenario.Scenario`, `gdtcore.spec.Spec` and
-// `gdtcore.suite.Suite`.
+// are `gdt.Scenario` and `gdt.Suite`.
 type Runnable interface {
 	Run(context.Context, *testing.T) error
 }


### PR DESCRIPTION
Also reduces the level of abstraction needed on `suite.From()` and `scenario.FromReader()` and `scenario.FromBytes()` so that they return concrete types not interfaces. Only the porcelain `gdt.From()` returns a Runnable interface now.