### PR TITLE
rename Scenario.Require to Scenario.Fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ they can instead have a test that looks like this:
 
 
 ```yaml
-require:
+fixtures:
  - books_api
 tests:
  - name: no such book was found
@@ -261,7 +261,7 @@ how `gdt` allows the test author to describe the same assertions
 ([`failures.yaml`](https://github.com/gdt-dev/gdt-examples/blob/main/http/tests/api/failures.yaml)):
 
 ```yaml
-require:
+fixtures:
  - books_api
 tests:
  - name: no such book was found
@@ -385,7 +385,7 @@ might create to describe the same assertions
 ([`create_then_get.yaml`](https://github.com/gdt-dev/gdt-examples/blob/main/http/tests/api/create_then_get.yaml)):
 
 ```yaml
-require:
+fixtures:
  - books_api
  - books_data
 tests:
@@ -425,7 +425,7 @@ All `gdt` scenarios have the following fields:
   contents
 * `defaults`: (optional) is a map, keyed by a plugin name, of default options
   and configuration values for that plugin.
-* `require`: (optional) list of strings indicating named fixtures that will be
+* `fixtures`: (optional) list of strings indicating named fixtures that will be
   started before any of the tests in the file are run
 * `tests`: list of [`Spec`][basespec] specializations that represent the
   runnable test units in the test scenario.

--- a/scenario/parse.go
+++ b/scenario/parse.go
@@ -47,15 +47,15 @@ func (s *Scenario) UnmarshalYAML(node *yaml.Node) error {
 				return gdterrors.ExpectedScalarAt(valNode)
 			}
 			s.Description = valNode.Value
-		case "require":
+		case "fixtures":
 			if valNode.Kind != yaml.SequenceNode {
 				return gdterrors.ExpectedSequenceAt(valNode)
 			}
-			requires := make([]string, len(valNode.Content))
-			for x, n := range valNode.Content {
-				requires[x] = n.Value
+			var fixtures []string
+			if err := valNode.Decode(&fixtures); err != nil {
+				return gdterrors.ExpectedSequenceAt(valNode)
 			}
-			s.Require = requires
+			s.Fixtures = fixtures
 		case "defaults":
 			if valNode.Kind != yaml.MappingNode {
 				return gdterrors.ExpectedMapAt(valNode)

--- a/scenario/parse_test.go
+++ b/scenario/parse_test.go
@@ -47,7 +47,7 @@ func TestNoTests(t *testing.T) {
 	assert.IsType(&scenario.Scenario{}, s)
 	assert.Equal("no-tests", s.Name)
 	assert.Equal(filepath.Join("testdata", "no-tests.yaml"), s.Path)
-	assert.Equal([]string{"books_api", "books_data"}, s.Require)
+	assert.Equal([]string{"books_api", "books_data"}, s.Fixtures)
 	assert.Equal(
 		map[string]interface{}{
 			"foo": &fooDefaults{
@@ -146,7 +146,7 @@ func TestKnownSpec(t *testing.T) {
 	assert.IsType(&scenario.Scenario{}, s)
 	assert.Equal("foo", s.Name)
 	assert.Equal(filepath.Join("testdata", "foo.yaml"), s.Path)
-	assert.Empty(s.Require)
+	assert.Empty(s.Fixtures)
 	assert.Equal(
 		map[string]interface{}{
 			"foo": &fooDefaults{
@@ -246,7 +246,7 @@ func TestEnvExpansion(t *testing.T) {
 	assert.IsType(&scenario.Scenario{}, s)
 	assert.Equal("env-expansion", s.Name)
 	assert.Equal(filepath.Join("testdata", "env-expansion.yaml"), s.Path)
-	assert.Empty(s.Require)
+	assert.Empty(s.Fixtures)
 	assert.Equal(
 		map[string]interface{}{
 			"foo": &fooDefaults{
@@ -308,7 +308,7 @@ func TestScenarioDefaults(t *testing.T) {
 	assert.IsType(&scenario.Scenario{}, s)
 	assert.Equal("foo-timeout", s.Name)
 	assert.Equal(filepath.Join("testdata", "foo-timeout.yaml"), s.Path)
-	assert.Empty(s.Require)
+	assert.Empty(s.Fixtures)
 	assert.Equal(
 		map[string]interface{}{
 			"foo":      &fooDefaults{},

--- a/scenario/run.go
+++ b/scenario/run.go
@@ -19,9 +19,9 @@ import (
 
 // Run executes the tests in the test scenario
 func (s *Scenario) Run(ctx context.Context, t *testing.T) error {
-	if len(s.Require) > 0 {
+	if len(s.Fixtures) > 0 {
 		fixtures := gdtcontext.Fixtures(ctx)
-		for _, fname := range s.Require {
+		for _, fname := range s.Fixtures {
 			lookup := strings.ToLower(fname)
 			fix, found := fixtures[lookup]
 			if !found {

--- a/scenario/scenario.go
+++ b/scenario/scenario.go
@@ -26,8 +26,8 @@ type Scenario struct {
 	// During parsing, plugins are handed this raw data and asked to interpret
 	// it into known configuration values for that plugin.
 	Defaults map[string]interface{} `yaml:"defaults,omitempty"`
-	// Require specifies an ordered list of fixtures the test case depends on.
-	Require []string `yaml:"require,omitempty"`
+	// Fixtures specifies an ordered list of fixtures the test case depends on.
+	Fixtures []string `yaml:"fixtures,omitempty"`
 	// Tests is the collection of test units in this test case. These will be
 	// the fully parsed and materialized plugin Spec structs.
 	Tests []gdttypes.TestUnit `yaml:"tests,omitempty"`
@@ -73,10 +73,10 @@ func WithDefaults(defaults map[string]interface{}) ScenarioModifier {
 	}
 }
 
-// WithRequires sets a test scenario's Requires attribute
-func WithRequires(require []string) ScenarioModifier {
+// WithFixtures sets a test scenario's Fixtures attribute
+func WithRequires(fixtures []string) ScenarioModifier {
 	return func(s *Scenario) {
-		s.Require = require
+		s.Fixtures = fixtures
 	}
 }
 

--- a/scenario/testdata/foo-fixtures.yaml
+++ b/scenario/testdata/foo-fixtures.yaml
@@ -1,6 +1,6 @@
 name: foo
 description: a scenario with some foo test specs
-require:
+fixtures:
   - baz
 tests:
   - foo: bar

--- a/scenario/testdata/no-tests.yaml
+++ b/scenario/testdata/no-tests.yaml
@@ -1,6 +1,6 @@
 name: no-tests
 description: a scenario with no tests in it
-require:
+fixtures:
  - books_api
  - books_data
 defaults:


### PR DESCRIPTION
The old name was a leftover from earlier days. Changing the `require` field to `fixtures` to better represent what is contained inside it.