### PR TITLE
feature: skip-if conditional scenario skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,9 @@ All `gdt` scenarios have the following fields:
   and configuration values for that plugin.
 * `fixtures`: (optional) list of strings indicating named fixtures that will be
   started before any of the tests in the file are run
+* `skip-if`: (optional) list of [`Spec`][basespec] specializations that will be
+  evaluated *before* running any test in the scenario. If any of these
+  conditions evaluates successfully, the test scenario will be skipped.
 * `tests`: list of [`Spec`][basespec] specializations that represent the
   runnable test units in the test scenario.
 

--- a/scenario/scenario.go
+++ b/scenario/scenario.go
@@ -28,6 +28,48 @@ type Scenario struct {
 	Defaults map[string]interface{} `yaml:"defaults,omitempty"`
 	// Fixtures specifies an ordered list of fixtures the test case depends on.
 	Fixtures []string `yaml:"fixtures,omitempty"`
+	// SkipIf contains a list of evaluable conditions. If any of the conditions
+	// evaluates successfully, the test scenario will be skipped.  This allows
+	// test authors to specify "pre-flight checks" that should pass before
+	// attempting any of the actions in the scenario's tests.
+	//
+	// For example, let's assume you have a `gdt-kube` scenario that looks like
+	// this:
+	//
+	// ```yaml
+	// tests:
+	//  - kube.create: manifests/nginx-deployment.yaml
+	//  - kube:
+	//      get: deployments/nginx
+	//      assert:
+	//        matches:
+	//          status:
+	//            readyReplicas: 2
+	//  - kube.delete: deployments/nginx
+	// ```
+	//
+	// If you execute the above test and there is already an 'nginx'
+	// deployment, the `kube.create` test will fail. To prevent the scenario
+	// from proceeding with the tests if an 'nginx' deployment already exists,
+	// you could add the following
+	//
+	// ```yaml
+	// skip-if:
+	//  - kube.get: deployments/nginx
+	// tests:
+	//  - kube.create: manifests/nginx-deployment.yaml
+	//  - kube:
+	//      get: deployments/nginx
+	//      assert:
+	//        matches:
+	//          status:
+	//            readyReplicas: 2
+	//  - kube.delete: deployments/nginx
+	// ```
+	//
+	// With the above, if an 'nginx' deployment exists already, the scenario
+	// will skip all the tests.
+	SkipIf []gdttypes.Evaluable `yaml:"skip-if,omitempty"`
 	// Tests is the collection of test units in this test case. These will be
 	// the fully parsed and materialized plugin Spec structs.
 	Tests []gdttypes.Evaluable `yaml:"tests,omitempty"`

--- a/scenario/stub_plugins_test.go
+++ b/scenario/stub_plugins_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	gdtcontext "github.com/gdt-dev/gdt/context"
+	"github.com/gdt-dev/gdt/debug"
 	"github.com/gdt-dev/gdt/errors"
 	gdterrors "github.com/gdt-dev/gdt/errors"
 	"github.com/gdt-dev/gdt/plugin"
@@ -217,6 +218,23 @@ func (s *fooSpec) UnmarshalYAML(node *yaml.Node) error {
 		}
 	}
 	return nil
+}
+
+func (s *fooSpec) Eval(ctx context.Context, t *testing.T) *result.Result {
+	fails := []error{}
+	t.Run(s.Title(), func(t *testing.T) {
+		debug.Printf(ctx, t, "in %s Foo=%s", s.Title(), s.Foo)
+		// This is just a silly test to demonstrate how to write Eval() methods
+		// for plugin Spec specialization classes.
+		if s.Name == "bar" && s.Foo != "bar" {
+			fail := fmt.Errorf("expected s.Foo = 'bar', got %s", s.Foo)
+			fails = append(fails, fail)
+		} else if s.Name != "bar" && s.Foo != "baz" {
+			fail := fmt.Errorf("expected s.Foo = 'baz', got %s", s.Foo)
+			fails = append(fails, fail)
+		}
+	})
+	return result.New(result.WithFailures(fails...))
 }
 
 type fooPlugin struct{}

--- a/scenario/testdata/skip-if.yaml
+++ b/scenario/testdata/skip-if.yaml
@@ -1,0 +1,11 @@
+name: skip-if
+description: a scenario with a skip-if condition
+skip-if:
+  - foo: bar
+    # This causes the evaluation to succeed (expects name=bar when foo=bar)
+    name: bar
+tests:
+  - foo: bar
+    # Normally this would cause the test to fail, but this will be skipped due
+    # to the skip-if above succeeding.
+    name: bizzy


### PR DESCRIPTION
Adds support for `skip-if` collection of evaluable conditions for a scenario. If any of these conditions fails, the test will be skipped.

SkipIf contains a list of evaluable conditions that must evaluate successfully before the scenario's tests are executed. This allows test authors to specify "pre-flight checks" that should pass before attempting any of the actions in the scenario's tests.

For example, let's assume you have a `gdt-kube` scenario that looks like this:

```yaml
tests:
 - kube.create: manifests/nginx-deployment.yaml
 - kube:
   get: deployments/nginx
   assert:
     matches:
       status:
         readyReplicas: 2
 - kube.delete: deployments/nginx
```

If you execute the above test and there is already an 'nginx' deployment, the `kube.create` test will fail. To prevent the scenario from proceeding with the tests if an 'nginx' deployment already exists, you could add the following

```yaml
skip-if:
 - kube.get: deployments/nginx
tests:
 - kube.create: manifests/nginx-deployment.yaml
 - kube:
   get: deployments/nginx
   assert:
     matches:
       status:
         readyReplicas: 2
 - kube.delete: deployments/nginx
```

With the above, if an 'nginx' deployment exists already, the scenario will skip all the tests.