### PR TITLE
nest `exec` plugin assertions under `assert` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,24 +486,26 @@ the base `Spec` fields listed above):
 * `shell`: (optional) a string with the specific shell to use in executing the
   command. If empty (the default), no shell is used to execute the command and
   instead the operating system's `exec` family of calls is used.
-* `exit_code`: (optional) an integer with the expected exit code from the
+* `assert`: (optional) an object describing the conditions that will be
+  asserted about the test action.
+* `assert.exit_code`: (optional) an integer with the expected exit code from the
   executed command. The default successful exit code is 0 and therefore you do
   not need to specify this if you expect a successful exit code.
-* `out`: (optional) a [`PipeExpect`][pipeexpect] object containing
+* `assert.out`: (optional) a [`PipeExpect`][pipeexpect] object containing
   assertions about content in `stdout`.
-* `out.is`: (optional) a string with the exact contents of `stdout` you expect
+* `assert.out.is`: (optional) a string with the exact contents of `stdout` you expect
   to get.
-* `out.contains`: (optional) a list of one or more strings that *all* must be
+* `assert.out.contains`: (optional) a list of one or more strings that *all* must be
   present in `stdout`.
-* `out.contains_one_of`: (optional) a list of one or more strings of which *at
+* `assert.out.contains_one_of`: (optional) a list of one or more strings of which *at
   least one* must be present in `stdout`.
-* `err`: (optional) a [`PipeAssertions`][pipeexpect] object containing
+* `assert.err`: (optional) a [`PipeAssertions`][pipeexpect] object containing
   assertions about content in `stderr`.
-* `err.is`: (optional) a string with the exact contents of `stderr` you expect
+* `assert.err.is`: (optional) a string with the exact contents of `stderr` you expect
   to get.
-* `err.contains`: (optional) a list of one or more strings that *all* must be
+* `assert.err.contains`: (optional) a list of one or more strings that *all* must be
   present in `stderr`.
-* `err.contains_one_of`: (optional) a list of one or more strings of which *at
+* `assert.err.contains_one_of`: (optional) a list of one or more strings of which *at
   least one* must be present in `stderr`.
 
 [execspec]: https://github.com/gdt-dev/gdt/blob/2791e11105fd3c36d1f11a7d111e089be7cdc84c/exec/spec.go#L11-L34

--- a/plugin/exec/eval.go
+++ b/plugin/exec/eval.go
@@ -71,8 +71,6 @@ func (s *Spec) Eval(ctx context.Context, t *testing.T) *result.Result {
 		eerr, _ := err.(*exec.ExitError)
 		ec = eerr.ExitCode()
 	}
-	assertions := newAssertions(
-		s.ExitCode, ec, s.Out, outbuf, s.Err, errbuf,
-	)
+	assertions := newAssertions(s.Assert, ec, outbuf, errbuf)
 	return result.New(result.WithFailures(assertions.Failures()...))
 }

--- a/plugin/exec/spec.go
+++ b/plugin/exec/spec.go
@@ -23,14 +23,8 @@ type Spec struct {
 	// (the default), no shell is used to execute the command and instead the
 	// operating system's `exec` family of calls is used.
 	Shell string `yaml:"shell,omitempty"`
-	// ExitCode is the expected exit code for the executed command. The default
-	// (0) is the universal successful exit code, so you only need to set this
-	// if you expect a non-successful result from executing the command.
-	ExitCode int `yaml:"exit_code,omitempty"`
-	// Out has things that are expected in the stdout response
-	Out *PipeExpect `yaml:"out,omitempty"`
-	// Err has things that are expected in the stderr response
-	Err *PipeExpect `yaml:"err,omitempty"`
+	// Assert is an object containing the conditions that the Spec will assert.
+	Assert *Expect `yaml:"assert,omitempty"`
 }
 
 func (s *Spec) SetBase(b gdttypes.Spec) {

--- a/plugin/exec/testdata/echo-cat.yaml
+++ b/plugin/exec/testdata/echo-cat.yaml
@@ -2,11 +2,13 @@ name: echo-cat
 description: a scenario that echoes the word "cat" and expects that output.
 tests:
   - exec: echo "cat"
-    out:
-      is: cat
+    assert:
+      out:
+        is: cat
   # To test the stderr assertions, we redirect stdout to stderr in a shell
   # command...
   - exec: "echo cat 1>&2"
     shell: sh
-    err:
-      is: cat
+    assert:
+      err:
+        is: cat

--- a/plugin/exec/testdata/ls-contains-one-of.yaml
+++ b/plugin/exec/testdata/ls-contains-one-of.yaml
@@ -2,17 +2,19 @@ name: ls-contains-one-of
 description: a scenario that runs the `ls` command and checks the output contains one of a set of strings
 tests:
   - exec: ls -l
-    out:
-      contains_one_of:
-       - thisdoesnotexist
-       - neitherdoesthisexist
-       - parse.go
+    assert:
+      out:
+        contains_one_of:
+         - thisdoesnotexist
+         - neitherdoesthisexist
+         - parse.go
   # To test the stderr assertions, we redirect stdout to stderr in a shell
   # command...
   - exec: "ls -l 1>&2"
     shell: sh
-    err:
-      contains_one_of:
-       - thisdoesnotexist
-       - neitherdoesthisexist
-       - parse.go
+    assert:
+      err:
+        contains_one_of:
+         - thisdoesnotexist
+         - neitherdoesthisexist
+         - parse.go

--- a/plugin/exec/testdata/ls-contains.yaml
+++ b/plugin/exec/testdata/ls-contains.yaml
@@ -2,13 +2,15 @@ name: ls-contains
 description: a scenario that runs the `ls` command and checks the output contains a string
 tests:
   - exec: ls -l
-    out:
-      contains:
-       - parse.go
+    assert:
+      out:
+        contains:
+         - parse.go
   # To test the stderr assertions, we redirect stdout to stderr in a shell
   # command...
   - exec: "ls -l 1>&2"
     shell: sh
-    err:
-      contains:
-        - parse.go
+    assert:
+      err:
+        contains:
+         - parse.go

--- a/plugin/exec/testdata/ls-with-exit-code.yaml
+++ b/plugin/exec/testdata/ls-with-exit-code.yaml
@@ -2,4 +2,5 @@ name: ls-with-exit-code
 description: a scenario that runs the `ls` command expecting a non-0 exit code
 tests:
   - exec: ls /this/dir/does/not/exist
-    exit_code: 2
+    assert:
+      exit_code: 2

--- a/plugin/exec/testdata/mac-ls-with-exit-code.yaml
+++ b/plugin/exec/testdata/mac-ls-with-exit-code.yaml
@@ -2,4 +2,5 @@ name: mac-ls-with-exit-code
 description: a scenario that runs the `ls` command expecting a non-0 exit code on Mac
 tests:
   - exec: ls /this/dir/does/not/exist
-    exit_code: 1
+    assert:
+      exit_code: 1

--- a/plugin/exec/testdata/windows-sleep-timeout.yaml
+++ b/plugin/exec/testdata/windows-sleep-timeout.yaml
@@ -10,4 +10,5 @@ tests:
       expected: true
     # the context's deadline cancels the pipe and results in a 1 result
     # code on Windows...
-    exit_code: 1
+    assert:
+      exit_code: 1

--- a/porcelain_test.go
+++ b/porcelain_test.go
@@ -20,15 +20,17 @@ import (
 
 func TestFromUnknownSourceType(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 
 	s, err := gdt.From(1)
-	assert.NotNil(err)
-	assert.Nil(s)
+	require.NotNil(err)
+	require.Nil(s)
 
 	assert.ErrorIs(err, gdterrors.ErrUnknownSourceType)
 }
 
 func TestFromFileNotFound(t *testing.T) {
+	assert := assert.New(t)
 	require := require.New(t)
 
 	fp := filepath.Join("path", "to", "nonexisting", "file.yaml")
@@ -36,7 +38,7 @@ func TestFromFileNotFound(t *testing.T) {
 	require.NotNil(err)
 	require.Nil(s)
 
-	require.True(os.IsNotExist(err))
+	assert.True(os.IsNotExist(err))
 }
 
 func TestFromSuite(t *testing.T) {
@@ -57,11 +59,12 @@ func TestFromSuite(t *testing.T) {
 
 func TestFromScenarioPath(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 
 	fp := filepath.Join("suite", "testdata", "exec", "ls.yaml")
 	s, err := gdt.From(fp)
-	assert.Nil(err)
-	assert.NotNil(s)
+	require.Nil(err)
+	require.NotNil(s)
 
 	sc, ok := s.(*scenario.Scenario)
 	assert.True(ok, "gdt.From() with dir path did not return a Scenario")
@@ -78,8 +81,8 @@ func TestFromScenarioReader(t *testing.T) {
 	f, err := os.Open(fp)
 	require.Nil(err)
 	s, err := gdt.From(f)
-	assert.Nil(err)
-	assert.NotNil(s)
+	require.Nil(err)
+	require.NotNil(s)
 
 	sc, ok := s.(*scenario.Scenario)
 	assert.True(ok, "gdt.From() from file path did not return a Scenario")
@@ -91,6 +94,7 @@ func TestFromScenarioReader(t *testing.T) {
 
 func TestFromScenarioBytes(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 
 	raw := `name: foo
 description: simple foo test
@@ -99,8 +103,8 @@ tests:
 `
 	b := []byte(raw)
 	s, err := gdt.From(b)
-	assert.Nil(err)
-	assert.NotNil(s)
+	require.Nil(err)
+	require.NotNil(s)
 
 	sc, ok := s.(*scenario.Scenario)
 	assert.True(ok, "gdt.From() with []byte did not return a Scenario")
@@ -111,20 +115,19 @@ tests:
 }
 
 func TestRunExecSuite(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 
 	fp := filepath.Join("suite", "testdata", "exec")
 	s, err := gdt.From(fp)
-	assert.Nil(err)
-	assert.NotNil(s)
+	require.Nil(err)
+	require.NotNil(s)
 
 	err = s.Run(context.TODO(), t)
-	assert.Nil(err)
-	assert.False(t.Failed())
+	require.Nil(err)
+	require.False(t.Failed())
 }
 
 func TestRunExecScenario(t *testing.T) {
-	assert := assert.New(t)
 	require := require.New(t)
 
 	fp := filepath.Join("suite", "testdata", "exec", "ls.yaml")
@@ -133,6 +136,6 @@ func TestRunExecScenario(t *testing.T) {
 	require.NotNil(s)
 
 	err = s.Run(context.TODO(), t)
-	assert.Nil(err)
-	assert.False(t.Failed())
+	require.Nil(err)
+	require.False(t.Failed())
 }

--- a/suite/from_test.go
+++ b/suite/from_test.go
@@ -10,22 +10,24 @@ import (
 	_ "github.com/gdt-dev/gdt/plugin/exec"
 	"github.com/gdt-dev/gdt/suite"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFromDirNoSuchDir(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 
 	s, err := suite.FromDir("nosuchdirectory")
-	assert.NotNil(err)
-	assert.Nil(s)
+	require.NotNil(err)
+	require.Nil(s)
 }
 
 func TestFromDirExecSuite(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 
 	s, err := suite.FromDir("testdata/exec")
-	assert.Nil(err)
-	assert.NotNil(s)
+	require.Nil(err)
+	require.NotNil(s)
 
 	assert.Equal("testdata/exec", s.Path)
 	assert.Len(s.Scenarios, 2)

--- a/suite/testdata/exec/echo-cat.yaml
+++ b/suite/testdata/exec/echo-cat.yaml
@@ -2,11 +2,13 @@ name: echo-cat
 description: a scenario that echoes the word "cat" and expects that output.
 tests:
   - exec: echo "cat"
-    out:
-      is: cat
+    assert:
+      out:
+        is: cat
   # To test the stderr assertions, we redirect stdout to stderr in a shell
   # command...
   - exec: "echo cat 1>&2"
     shell: sh
-    err:
-      is: cat
+    assert:
+      err:
+        is: cat


### PR DESCRIPTION
I'm aligning all of the plugin assertion fields with a name of `assert`. This commit changes the first plugin, `exec` to nest the `exit_code`, `err` and `out` assertion structs under an `assert` field object in the Spec.

So, instead of this:

```yaml
tests:
 - exec: echo cat
   out:
     is: cat
```

you now do this:

```yaml
tests:
 - exec: echo cat
   assert:
     out:
       is: cat
```

I'm changing the `http` plugin's assertions block from `response` to `assert` and the `kube` plugin's assertions block from `kube.assert` to just `assert` in followup PRs in those repositories.