### PR TITLE
don't add non-Scenario files to Suite

### DIFF
--- a/suite/from.go
+++ b/suite/from.go
@@ -50,6 +50,11 @@ func FromDir(
 			if err != nil {
 				return err
 			}
+			if len(tc.Tests) == 0 {
+				// Either wasn't a test scenario or didn't have any tests in
+				// it, so ignore...
+				return nil
+			}
 			s.Append(tc)
 			return nil
 		},

--- a/suite/from_test.go
+++ b/suite/from_test.go
@@ -30,5 +30,8 @@ func TestFromDirExecSuite(t *testing.T) {
 	require.NotNil(s)
 
 	assert.Equal("testdata/exec", s.Path)
+	// NOTE(jaypipes): There are actually 3 valid YAML files in the
+	// suite/testdata/exec suite, but one isn't a gdt scenario and therefore
+	// should not appear in the collected Suite.Tests.
 	assert.Len(s.Scenarios, 2)
 }

--- a/suite/testdata/exec/not-a-scenario.yaml
+++ b/suite/testdata/exec/not-a-scenario.yaml
@@ -1,0 +1,4 @@
+this:
+  is: valid YAML
+but:
+  not: a gdt scenario


### PR DESCRIPTION
When processing a Suite, if the suite directory contains valid YAML files that are not `gdt` Scenarios (for example, valid Kubernetes CRDs), don't add those to the Suite.Tests collection. Same for valid `gdt` Scenarios that don't have any tests in them.

Closes Issue #7