### PR TITLE
use `path-formats` for JSON Expect

### DIFF
--- a/.github/workflows/gate-tests.yml
+++ b/.github/workflows/gate-tests.yml
@@ -24,6 +24,7 @@ jobs:
          disable-sudo: true
          allowed-endpoints: >
            github.com:443
+           proxy.golang.org:443
      - name: checkout code
        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
      - name: setup go

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ tests:
        paths:
          $.author.name: Ernest Hemingway
          $.publisher.address.state: New York
-       path_formats:
+       path-formats:
          $.id: uuid4
 ```
 

--- a/assertion/json/json.go
+++ b/assertion/json/json.go
@@ -36,7 +36,7 @@ type Expect struct {
 	Paths map[string]string `yaml:"paths,omitempty"`
 	// PathFormats is a map, keyed by JSONPath expression, of expected formats
 	// that values found at the expression should have.
-	PathFormats map[string]string `yaml:"path_formats,omitempty"`
+	PathFormats map[string]string `yaml:"path-formats,omitempty"`
 	// Schema is a file path to the JSONSchema that the JSON should validate
 	// against.
 	Schema string `yaml:"schema,omitempty"`
@@ -112,7 +112,7 @@ func (e *Expect) UnmarshalYAML(node *yaml.Node) error {
 				}
 			}
 			e.Paths = paths
-		case "path_formats":
+		case "path_formats", "path-formats":
 			if valNode.Kind != yaml.MappingNode {
 				return gdterrors.ExpectedMapAt(valNode)
 			}


### PR DESCRIPTION
Aligns with the `snake-case` YAML field names for `path-formats` instead of `path_formats` but keeps the ability to use `path_formats` for backwards-compat.