### PR TITLE
ensure all parse-time errors show line/col in YAML

### DIFF
--- a/assertion/json/errors.go
+++ b/assertion/json/errors.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	gdterrors "github.com/gdt-dev/gdt/errors"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -78,32 +79,51 @@ var (
 
 // UnsupportedJSONSchemaReference returns ErrUnsupportedJSONSchemaReference for
 // a supplied URL.
-func UnsupportedJSONSchemaReference(url string) error {
-	return fmt.Errorf("%w: %s", ErrUnsupportedJSONSchemaReference, url)
+func UnsupportedJSONSchemaReference(url string, node *yaml.Node) error {
+	return fmt.Errorf(
+		"%w: %s at line %d, column %d",
+		ErrUnsupportedJSONSchemaReference, url, node.Line, node.Column,
+	)
 }
 
 // JSONSchemaFileNotFound returns ErrJSONSchemaFileNotFound for a supplied
 // path.
-func JSONSchemaFileNotFound(path string) error {
-	return fmt.Errorf("%w: %s", ErrJSONSchemaFileNotFound, path)
+func JSONSchemaFileNotFound(path string, node *yaml.Node) error {
+	return fmt.Errorf(
+		"%w: %s at line %d, column %d",
+		ErrJSONSchemaFileNotFound, path, node.Line, node.Column,
+	)
 }
 
 // JSONUnmarshalError returns an ErrFailure when JSON content cannot be
 // decoded.
-func JSONUnmarshalError(err error) error {
-	return fmt.Errorf("%w: %s", ErrJSONUnmarshalError, err)
+func JSONUnmarshalError(err error, node *yaml.Node) error {
+	if node != nil {
+		return fmt.Errorf(
+			"%w: %s at line %d, column %d",
+			ErrJSONUnmarshalError, err, node.Line, node.Column,
+		)
+	} else {
+		return fmt.Errorf("%w: %s", ErrJSONUnmarshalError, err)
+	}
 }
 
 // JSONPathInvalid returns an ErrParse when a JSONPath expression could not be
 // parsed.
-func JSONPathInvalid(path string, err error) error {
-	return fmt.Errorf("%w: %s: %s", ErrJSONPathInvalid, path, err)
+func JSONPathInvalid(path string, err error, node *yaml.Node) error {
+	return fmt.Errorf(
+		"%w: %s: %s at line %d, column %d",
+		ErrJSONPathInvalid, path, err, node.Line, node.Column,
+	)
 }
 
 // JSONPathInvalidNoRoot returns an ErrJSONPathInvalidNoRoot when a JSONPath
 // expression does not start with '$'.
-func JSONPathInvalidNoRoot(path string) error {
-	return fmt.Errorf("%w: %s", ErrJSONPathInvalidNoRoot, path)
+func JSONPathInvalidNoRoot(path string, node *yaml.Node) error {
+	return fmt.Errorf(
+		"%w: %s at line %d, column %d",
+		ErrJSONPathInvalidNoRoot, path, node.Line, node.Column,
+	)
 }
 
 // JSONPathNotFound returns an ErrFailure when a JSONPath expression could not

--- a/assertion/json/json.go
+++ b/assertion/json/json.go
@@ -75,7 +75,7 @@ func (e *Expect) UnmarshalYAML(node *yaml.Node) error {
 			schemaURL := valNode.Value
 			if strings.HasPrefix(schemaURL, "http://") || strings.HasPrefix(schemaURL, "https://") {
 				// TODO(jaypipes): Support network lookups?
-				return UnsupportedJSONSchemaReference(schemaURL)
+				return UnsupportedJSONSchemaReference(schemaURL, valNode)
 			}
 			// Convert relative filepaths to absolute filepaths rooted in the context's
 			// testdir after stripping any "file://" scheme prefix
@@ -84,7 +84,7 @@ func (e *Expect) UnmarshalYAML(node *yaml.Node) error {
 
 			f, err := os.Open(schemaURL)
 			if err != nil {
-				return JSONSchemaFileNotFound(schemaURL)
+				return JSONSchemaFileNotFound(schemaURL, valNode)
 			}
 			defer f.Close()
 			if runtime.GOOS == "windows" {
@@ -105,10 +105,10 @@ func (e *Expect) UnmarshalYAML(node *yaml.Node) error {
 			}
 			for path, _ := range paths {
 				if len(path) == 0 || path[0] != '$' {
-					return JSONPathInvalidNoRoot(path)
+					return JSONPathInvalidNoRoot(path, valNode)
 				}
 				if _, err := lang.NewEvaluable(path); err != nil {
-					return JSONPathInvalid(path, err)
+					return JSONPathInvalid(path, err, valNode)
 				}
 			}
 			e.Paths = paths
@@ -122,10 +122,10 @@ func (e *Expect) UnmarshalYAML(node *yaml.Node) error {
 			}
 			for pathFormat, _ := range pathFormats {
 				if len(pathFormat) == 0 || pathFormat[0] != '$' {
-					return JSONPathInvalidNoRoot(pathFormat)
+					return JSONPathInvalidNoRoot(pathFormat, valNode)
 				}
 				if _, err := lang.NewEvaluable(pathFormat); err != nil {
-					return JSONPathInvalid(pathFormat, err)
+					return JSONPathInvalid(pathFormat, err, valNode)
 				}
 			}
 			e.PathFormats = pathFormats
@@ -228,7 +228,7 @@ func (a *assertions) pathsOK() bool {
 	}
 	v := interface{}(nil)
 	if err := json.Unmarshal(a.content, &v); err != nil {
-		a.Fail(JSONUnmarshalError(err))
+		a.Fail(JSONUnmarshalError(err, nil))
 		a.terminal = true
 		return false
 	}
@@ -299,7 +299,7 @@ func (a *assertions) pathFormatsOK() bool {
 	}
 	v := interface{}(nil)
 	if e := json.Unmarshal(a.content, &v); e != nil {
-		a.Fail(JSONUnmarshalError(e))
+		a.Fail(JSONUnmarshalError(e, nil))
 		a.terminal = true
 		return false
 	}

--- a/errors/parse.go
+++ b/errors/parse.go
@@ -151,6 +151,9 @@ func UnknownSourceType(source interface{}) error {
 }
 
 // FileNotFound returns ErrFileNotFound for a given file path
-func FileNotFound(path string) error {
-	return fmt.Errorf("%w: %s", ErrFileNotFound, path)
+func FileNotFound(path string, node *yaml.Node) error {
+	return fmt.Errorf(
+		"%w: %s at line %d, column %d",
+		ErrFileNotFound, path, node.Line, node.Column,
+	)
 }

--- a/plugin/exec/errors.go
+++ b/plugin/exec/errors.go
@@ -35,10 +35,10 @@ func ExecEmpty(node *yaml.Node) error {
 
 // ExecInvalidShellParse returns an ErrExecInvalid with the error from
 // shlex.Split
-func ExecInvalidShellParse(err error) error {
+func ExecInvalidShellParse(err error, node *yaml.Node) error {
 	return fmt.Errorf(
-		"%w: cannot parse shell args: %s",
-		ErrExecInvalid, err,
+		"%w: cannot parse shell args: %s at line %d, column %d",
+		ErrExecInvalid, err, node.Line, node.Column,
 	)
 }
 

--- a/plugin/exec/parse.go
+++ b/plugin/exec/parse.go
@@ -37,6 +37,7 @@ func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return errors.ExpectedMapAt(node)
 	}
+	var execValNode *yaml.Node
 	// maps/structs are stored in a top-level Node.Content field which is a
 	// concatenated slice of Node pointers in pairs of key/values.
 	for i := 0; i < len(node.Content); i += 2 {
@@ -59,6 +60,7 @@ func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 			if valNode.Kind != yaml.ScalarNode {
 				return errors.ExpectedScalarAt(valNode)
 			}
+			execValNode = valNode
 			s.Exec = strings.TrimSpace(valNode.Value)
 			if s.Exec == "" {
 				return ExecEmpty(valNode)
@@ -94,7 +96,7 @@ func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 	if s.Shell != "" {
 		_, err := shlex.Split(s.Exec)
 		if err != nil {
-			return ExecInvalidShellParse(err)
+			return ExecInvalidShellParse(err, execValNode)
 		}
 	}
 	return nil


### PR DESCRIPTION
To give users the most useful information about a syntax or parse-time error in their gdt tests, make sure that all parse-time error functions accept a `*yaml.Node` parameter that we can grab line/column information.`