### PR TITLE
`assert.out.none` and `assert.err.none` to exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,25 +491,29 @@ the base `Spec` fields listed above):
   instead the operating system's `exec` family of calls is used.
 * `assert`: (optional) an object describing the conditions that will be
   asserted about the test action.
-* `assert.exit_code`: (optional) an integer with the expected exit code from the
+* `assert.exit-code`: (optional) an integer with the expected exit code from the
   executed command. The default successful exit code is 0 and therefore you do
   not need to specify this if you expect a successful exit code.
 * `assert.out`: (optional) a [`PipeExpect`][pipeexpect] object containing
   assertions about content in `stdout`.
 * `assert.out.is`: (optional) a string with the exact contents of `stdout` you expect
   to get.
-* `assert.out.contains`: (optional) a list of one or more strings that *all* must be
+* `assert.out.all`: (optional) a string or list of strings that *all* must be
   present in `stdout`.
-* `assert.out.contains_one_of`: (optional) a list of one or more strings of which *at
+* `assert.out.any`: (optional) a string or list of strings of which *at
   least one* must be present in `stdout`.
+* `assert.out.none`: (optional) a string or list of strings of which *none
+  should be present* in `stdout`.
 * `assert.err`: (optional) a [`PipeAssertions`][pipeexpect] object containing
   assertions about content in `stderr`.
 * `assert.err.is`: (optional) a string with the exact contents of `stderr` you expect
   to get.
-* `assert.err.contains`: (optional) a list of one or more strings that *all* must be
+* `assert.err.all`: (optional) a string or list of strings that *all* must be
   present in `stderr`.
-* `assert.err.contains_one_of`: (optional) a list of one or more strings of which *at
+* `assert.err.any`: (optional) a string or list of strings of which *at
   least one* must be present in `stderr`.
+* `assert.err.none`: (optional) a string or list of strings of which *none
+  should be present* in `stderr`.
 * `on`: (optional) an object describing actions to take upon certain
   conditions.
 * `on.fail`: (optional) an object describing an action to take when any

--- a/errors/failure.go
+++ b/errors/failure.go
@@ -19,6 +19,9 @@ var (
 	// ErrNotEqual is an ErrFailure when an expected thing doesn't equal an
 	// observed thing.
 	ErrNotEqual = fmt.Errorf("%w: not equal", ErrFailure)
+	// ErrIn is an ErrFailure when a thing unexpectedly appears in an
+	// container.
+	ErrIn = fmt.Errorf("%w: in", ErrFailure)
 	// ErrNotIn is an ErrFailure when an expected thing doesn't appear in an
 	// expected container.
 	ErrNotIn = fmt.Errorf("%w: not in", ErrFailure)
@@ -56,6 +59,14 @@ func NotEqualLength(exp, got int) error {
 // observed thing.
 func NotEqual(exp, got interface{}) error {
 	return fmt.Errorf("%w: expected %v but got %v", ErrNotEqual, exp, got)
+}
+
+// In returns an ErrIn when a thing unexpectedly appears in a container.
+func In(element, container interface{}) error {
+	return fmt.Errorf(
+		"%w: expected %v not to contain %v",
+		ErrIn, container, element,
+	)
 }
 
 // NotIn returns an ErrNotIn when an expected thing doesn't appear in an

--- a/plugin/exec/eval_test.go
+++ b/plugin/exec/eval_test.go
@@ -138,6 +138,25 @@ func TestContainsOneOf(t *testing.T) {
 	require.Nil(err)
 }
 
+func TestContainsNoneOf(t *testing.T) {
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "ls-contains-none-of.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	s, err := scenario.FromReader(
+		f,
+		scenario.WithPath(fp),
+	)
+	require.Nil(err)
+	require.NotNil(s)
+
+	ctx := context.TODO()
+	err = s.Run(ctx, t)
+	require.Nil(err)
+}
+
 func TestSleepTimeout(t *testing.T) {
 	require := require.New(t)
 

--- a/plugin/exec/testdata/ls-contains-none-of.yaml
+++ b/plugin/exec/testdata/ls-contains-none-of.yaml
@@ -1,0 +1,30 @@
+name: ls-contains-none-of
+description: a scenario that runs the `ls` command and checks the output does not contain a string
+tests:
+  - exec: ls -l
+    assert:
+      out:
+        none:
+         - notexisting.go
+  # Variants of contains-none-of
+  - exec: ls -l
+    assert:
+      out:
+        none-of: notexisting.go
+  - exec: ls -l
+    assert:
+      out:
+        contains_none_of:
+         - notexisting.go
+  - exec: ls -l
+    assert:
+      out:
+        none-of: notexisting.go
+  # To test the stderr assertions, we redirect stdout to stderr in a shell
+  # command...
+  - exec: "ls -l 1>&2"
+    shell: sh
+    assert:
+      err:
+        none:
+         - notexisting.go

--- a/plugin/exec/testdata/ls-contains-one-of.yaml
+++ b/plugin/exec/testdata/ls-contains-one-of.yaml
@@ -4,17 +4,34 @@ tests:
   - exec: ls -l
     assert:
       out:
+        any:
+         - thisdoesnotexist
+         - neitherdoesthisexist
+         - parse.go
+  # Variants of contains-any
+  - exec: ls -l
+    assert:
+      out:
         contains_one_of:
          - thisdoesnotexist
          - neitherdoesthisexist
          - parse.go
+  - exec: ls -l
+    assert:
+      out:
+        contains-any:
+         - parse.go
+  - exec: ls -l
+    assert:
+      out:
+        any: parse.go
   # To test the stderr assertions, we redirect stdout to stderr in a shell
   # command...
   - exec: "ls -l 1>&2"
     shell: sh
     assert:
       err:
-        contains_one_of:
+        any:
          - thisdoesnotexist
          - neitherdoesthisexist
          - parse.go

--- a/plugin/exec/testdata/ls-contains.yaml
+++ b/plugin/exec/testdata/ls-contains.yaml
@@ -6,6 +6,29 @@ tests:
       out:
         contains:
          - parse.go
+  # Variants of contains-all
+  - exec: ls -l
+    assert:
+      out:
+        is: parse.go
+  - exec: ls -l
+    assert:
+      out:
+        is:
+         - parse.go
+  - exec: ls -l
+    assert:
+      out:
+        contains: parse.go
+  - exec: ls -l
+    assert:
+      out:
+        contains-all:
+         - parse.go
+  - exec: ls -l
+    assert:
+      out:
+        all: parse.go
   # To test the stderr assertions, we redirect stdout to stderr in a shell
   # command...
   - exec: "ls -l 1>&2"

--- a/plugin/exec/testdata/ls-with-exit-code.yaml
+++ b/plugin/exec/testdata/ls-with-exit-code.yaml
@@ -3,4 +3,4 @@ description: a scenario that runs the `ls` command expecting a non-0 exit code
 tests:
   - exec: ls /this/dir/does/not/exist
     assert:
-      exit_code: 2
+      exit-code: 2

--- a/plugin/exec/testdata/mac-ls-with-exit-code.yaml
+++ b/plugin/exec/testdata/mac-ls-with-exit-code.yaml
@@ -3,4 +3,4 @@ description: a scenario that runs the `ls` command expecting a non-0 exit code o
 tests:
   - exec: ls /this/dir/does/not/exist
     assert:
-      exit_code: 1
+      exit-code: 1

--- a/plugin/exec/testdata/windows-sleep-timeout.yaml
+++ b/plugin/exec/testdata/windows-sleep-timeout.yaml
@@ -11,4 +11,4 @@ tests:
     # the context's deadline cancels the pipe and results in a 1 result
     # code on Windows...
     assert:
-      exit_code: 1
+      exit-code: 1


### PR DESCRIPTION
Makes the assertion fields of the exec plugin's `assert` struct more flexible and adds a new `assert.out.none` and `assert.err.none` field that contains a string or strings that should *not* appear in either stdout or stderr pipes from the exec command.

The `plugin/exec.PipeExpect` struct now contains three fields, each of which are `types.FlexStrings` that can contain either a string or a list of strings. There is now a custom YAML unmarshaler for `PipeExpect` which allows a flexible naming convention to be used for specifying assertions:

All of these examples are valid and represent human-readable assertions:

```yaml
tests:
  # Variants of contains
  - exec: ls -l
    assert:
      out:
        contains:
         - parse.go
  - exec: ls -l
    assert:
      out:
        is: parse.go
  - exec: ls -l
    assert:
      out:
        is:
         - parse.go
  - exec: ls -l
    assert:
      out:
        contains: parse.go
  - exec: ls -l
    assert:
      out:
        contains-all:
         - parse.go
  - exec: ls -l
    assert:
      out:
        all: parse.go
  # Variants of contains-any
  - exec: ls -l
    assert:
      out:
        any:
         - thisdoesnotexist
         - neitherdoesthisexist
         - parse.go
  - exec: ls -l
    assert:
      out:
        contains_one_of:
         - thisdoesnotexist
         - neitherdoesthisexist
         - parse.go
  - exec: ls -l
    assert:
      out:
        contains-any:
         - parse.go
  - exec: ls -l
    assert:
      out:
        any: parse.go
  # Variants of contains-none-of
  - exec: ls -l
    assert:
      out:
        none:
         - notexisting.go
  - exec: ls -l
    assert:
      out:
        none-of: notexisting.go
  - exec: ls -l
    assert:
      out:
        contains_none_of:
         - notexisting.go
  - exec: ls -l
    assert:
      out:
        none-of: notexisting.go
```