### PR TITLE
uplift Go and Github action runners

### DIFF
--- a/.github/workflows/fmtcheck.yml
+++ b/.github/workflows/fmtcheck.yml
@@ -1,4 +1,4 @@
-name: gate tests
+name: fmtcheck
 
 on:
   push:
@@ -10,12 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    strategy:
-      matrix:
-        go: ['1.19', '1.20', '1.21']
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+  fmtcheck:
+    runs-on: ubuntu-latest
     steps:
      - name: harden runner
        uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
@@ -26,6 +22,7 @@ jobs:
            github.com:443
            api.github.com:443
            proxy.github.com:443
+           proxy.golang.org:443
            raw.githubusercontent.com:443
            objects.githubusercontent.com:443
            proxy.golang.org:443
@@ -34,6 +31,6 @@ jobs:
      - name: setup go
        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
        with:
-         go-version: ${{ matrix.go }}
-         check-latest: true
-     - run: go test -v ./...
+         go-version: 1.21
+     - name: check fmt
+       run: 'bash -c "diff -u <(echo -n) <(gofmt -d .)"'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pull-requests: read # needed for only-new-issues option below
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+     - name: harden runner
+       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       with:
+         egress-policy: block
+         disable-sudo: true
+         allowed-endpoints: >
+           github.com:443
+           api.github.com:443
+           proxy.github.com:443
+           proxy.golang.org:443
+           raw.githubusercontent.com:443
+           objects.githubusercontent.com:443
+           proxy.golang.org:443
+     - name: checkout code
+       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+     - name: setup go
+       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+       with:
+         go-version: 1.21
+     - name: lint
+       uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+       with:
+         version: v1.53
+         args: --timeout=5m0s --verbose
+         only-new-issues: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go: ['1.19', '1.20', '1.21']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+     - name: harden runner
+       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       with:
+         egress-policy: block
+         disable-sudo: true
+         allowed-endpoints: >
+           github.com:443
+           api.github.com:443
+           proxy.github.com:443
+           raw.githubusercontent.com:443
+           objects.githubusercontent.com:443
+           proxy.golang.org:443
+     - name: checkout code
+       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+     - name: setup go
+       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+       with:
+         go-version: ${{ matrix.go }}
+         check-latest: true
+     - run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/gdt-dev/gdt.svg)](https://pkg.go.dev/github.com/gdt-dev/gdt)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gdt-dev/gdt)](https://goreportcard.com/report/github.com/gdt-dev/gdt)
-[![Build Status](https://github.com/gdt-dev/gdt/actions/workflows/gate-tests.yml/badge.svg?branch=main)](https://github.com/gdt-dev/gdt/actions)
+[![Build Status](https://github.com/gdt-dev/gdt/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/gdt-dev/gdt/actions)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 <div style="float: left">

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gdt-dev/gdt
 
-go 1.19
+go 1.21
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1


### PR DESCRIPTION
Uplifts Go to 1.21 and hardens our Github action runners.