### PR TITLE
add context argument to fixture Stop/Start

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func fooStart() {}
+func fooStart(_ context.Context) {}
 
 type fooDefaults struct {
 	Foo string `yaml:"foo"`

--- a/fixture/generic.go
+++ b/fixture/generic.go
@@ -5,6 +5,7 @@
 package fixture
 
 import (
+	"context"
 	"strings"
 
 	gdttypes "github.com/gdt-dev/gdt/types"
@@ -12,22 +13,22 @@ import (
 
 // genericFixture adapts functions and state dicts into the Fixture type
 type genericFixture struct {
-	starter func()
-	stopper func()
+	starter func(context.Context)
+	stopper func(context.Context)
 	state   map[string]interface{}
 }
 
 // Start sets up any resources the fixture uses
-func (f *genericFixture) Start() {
+func (f *genericFixture) Start(ctx context.Context) {
 	if f.starter != nil {
-		f.starter()
+		f.starter(ctx)
 	}
 }
 
 // Stop cleans up any resources the fixture uses
-func (f *genericFixture) Stop() {
+func (f *genericFixture) Stop(ctx context.Context) {
 	if f.stopper != nil {
-		f.stopper()
+		f.stopper(ctx)
 	}
 }
 
@@ -54,14 +55,14 @@ func (f *genericFixture) State(key string) interface{} {
 type genericFixtureModifier func(s *genericFixture)
 
 // WithStarter allows a starter functor to be adapted into a fixture
-func WithStarter(starter func()) genericFixtureModifier {
+func WithStarter(starter func(context.Context)) genericFixtureModifier {
 	return func(f *genericFixture) {
 		f.starter = starter
 	}
 }
 
 // WithStopper allows a stopper functor to be adapted into a fixture
-func WithStopper(stopper func()) genericFixtureModifier {
+func WithStopper(stopper func(context.Context)) genericFixtureModifier {
 	return func(f *genericFixture) {
 		f.stopper = stopper
 	}

--- a/fixture/generic_test.go
+++ b/fixture/generic_test.go
@@ -5,6 +5,7 @@
 package fixture_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gdt-dev/gdt/fixture"
@@ -35,7 +36,7 @@ func TestStarter(t *testing.T) {
 
 	started := false
 
-	starter := func() {
+	starter := func(_ context.Context) {
 		started = true
 	}
 
@@ -45,7 +46,7 @@ func TestStarter(t *testing.T) {
 
 	assert.False(started)
 
-	f.Start()
+	f.Start(context.TODO())
 
 	assert.True(started)
 }
@@ -55,7 +56,7 @@ func TestStopper(t *testing.T) {
 
 	stopped := false
 
-	stopper := func() {
+	stopper := func(_ context.Context) {
 		stopped = true
 	}
 
@@ -65,7 +66,7 @@ func TestStopper(t *testing.T) {
 
 	assert.False(stopped)
 
-	f.Stop()
+	f.Stop(context.TODO())
 
 	assert.True(stopped)
 }

--- a/fixture/json/json.go
+++ b/fixture/json/json.go
@@ -5,6 +5,7 @@
 package json
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -18,9 +19,9 @@ type jsonFixture struct {
 	data interface{}
 }
 
-func (f *jsonFixture) Start() {}
+func (f *jsonFixture) Start(_ context.Context) {}
 
-func (f *jsonFixture) Stop() {}
+func (f *jsonFixture) Stop(_ context.Context) {}
 
 // HasState returns true if the supplied JSONPath expression results in a found
 // value in the fixture's data

--- a/scenario/run.go
+++ b/scenario/run.go
@@ -32,8 +32,8 @@ func (s *Scenario) Run(ctx context.Context, t *testing.T) error {
 			if !found {
 				return gdterrors.RequiredFixtureMissing(fname)
 			}
-			fix.Start()
-			defer fix.Stop()
+			fix.Start(ctx)
+			defer fix.Stop(ctx)
 		}
 	}
 	var rterr error

--- a/types/fixture.go
+++ b/types/fixture.go
@@ -4,12 +4,14 @@
 
 package types
 
+import "context"
+
 // A Fixture allows state to be passed from setups
 type Fixture interface {
 	// Start sets up the fixture
-	Start()
+	Start(context.Context)
 	// Stop tears down the fixture, cleaning up any owned resources
-	Stop()
+	Stop(context.Context)
 	// HasState returns true if the fixture contains some state with the given
 	// key
 	HasState(string) bool


### PR DESCRIPTION
In order to integrate fixtures into debug printing, we needed to add context arguments to the `fixture.Start()` and `fixture.Stop()` methods.