### PR TITLE
add `error` return to `Fixture.Start()`

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func fooStart(_ context.Context) {}
+func fooStart(_ context.Context) error { return nil }
 
 type fooDefaults struct {
 	Foo string `yaml:"foo"`

--- a/fixture/generic.go
+++ b/fixture/generic.go
@@ -13,16 +13,17 @@ import (
 
 // genericFixture adapts functions and state dicts into the Fixture type
 type genericFixture struct {
-	starter func(context.Context)
+	starter func(context.Context) error
 	stopper func(context.Context)
 	state   map[string]interface{}
 }
 
 // Start sets up any resources the fixture uses
-func (f *genericFixture) Start(ctx context.Context) {
+func (f *genericFixture) Start(ctx context.Context) error {
 	if f.starter != nil {
-		f.starter(ctx)
+		return f.starter(ctx)
 	}
+	return nil
 }
 
 // Stop cleans up any resources the fixture uses
@@ -55,7 +56,7 @@ func (f *genericFixture) State(key string) interface{} {
 type genericFixtureModifier func(s *genericFixture)
 
 // WithStarter allows a starter functor to be adapted into a fixture
-func WithStarter(starter func(context.Context)) genericFixtureModifier {
+func WithStarter(starter func(context.Context) error) genericFixtureModifier {
 	return func(f *genericFixture) {
 		f.starter = starter
 	}

--- a/fixture/generic_test.go
+++ b/fixture/generic_test.go
@@ -36,8 +36,9 @@ func TestStarter(t *testing.T) {
 
 	started := false
 
-	starter := func(_ context.Context) {
+	starter := func(_ context.Context) error {
 		started = true
+		return nil
 	}
 
 	f := fixture.New(

--- a/fixture/json/json.go
+++ b/fixture/json/json.go
@@ -19,7 +19,7 @@ type jsonFixture struct {
 	data interface{}
 }
 
-func (f *jsonFixture) Start(_ context.Context) {}
+func (f *jsonFixture) Start(_ context.Context) error { return nil }
 
 func (f *jsonFixture) Stop(_ context.Context) {}
 

--- a/scenario/run.go
+++ b/scenario/run.go
@@ -32,7 +32,9 @@ func (s *Scenario) Run(ctx context.Context, t *testing.T) error {
 			if !found {
 				return gdterrors.RequiredFixtureMissing(fname)
 			}
-			fix.Start(ctx)
+			if err := fix.Start(ctx); err != nil {
+				return err
+			}
 			defer fix.Stop(ctx)
 		}
 	}

--- a/scenario/run_test.go
+++ b/scenario/run_test.go
@@ -67,6 +67,26 @@ func TestMissingFixtures(t *testing.T) {
 	assert.ErrorIs(err, gdterrors.RuntimeError)
 }
 
+func TestFixtureStartError(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	fp := filepath.Join("testdata", "fixture-start-error.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	s, err := scenario.FromReader(f, scenario.WithPath(fp))
+	require.Nil(err)
+	require.NotNil(s)
+
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterFixture(ctx, "start-error", errStarterFixture)
+
+	err = s.Run(ctx, t)
+	assert.NotNil(err)
+	assert.ErrorContains(err, "error starting fixture!")
+}
+
 func TestDebugFlushing(t *testing.T) {
 	require := require.New(t)
 

--- a/scenario/stub_fixtures_test.go
+++ b/scenario/stub_fixtures_test.go
@@ -1,0 +1,22 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package scenario_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gdt-dev/gdt/fixture"
+)
+
+var (
+	errStarter = func(_ context.Context) error {
+		return fmt.Errorf("error starting fixture!")
+	}
+
+	errStarterFixture = fixture.New(
+		fixture.WithStarter(errStarter),
+	)
+)

--- a/scenario/testdata/fixture-start-error.yaml
+++ b/scenario/testdata/fixture-start-error.yaml
@@ -1,0 +1,7 @@
+name: fixture-start-error
+description: a scenario with a fixture that errors in start
+fixtures:
+  - start-error
+tests:
+  - foo: bar
+

--- a/types/fixture.go
+++ b/types/fixture.go
@@ -9,7 +9,7 @@ import "context"
 // A Fixture allows state to be passed from setups
 type Fixture interface {
 	// Start sets up the fixture
-	Start(context.Context)
+	Start(context.Context) error
 	// Stop tears down the fixture, cleaning up any owned resources
 	Stop(context.Context)
 	// HasState returns true if the fixture contains some state with the given


### PR DESCRIPTION
In order to better handle setup failures in fixtures, the `fixture.Start()` interface method should return `error`.

Issue #28