### PR TITLE
add custom retry configuration

### DIFF
--- a/errors/parse.go
+++ b/errors/parse.go
@@ -53,13 +53,23 @@ var (
 	ErrExpectedScalarOrSequence = fmt.Errorf(
 		"%w: expected scalar or sequence of scalars field", ErrParse,
 	)
-	// ErrParseTimeout indicates that the timeout specification was not valid.
+	// ErrExpectedTimeout indicates that the timeout specification was not
+	// valid.
 	ErrExpectedTimeout = fmt.Errorf(
 		"%w: expected timeout specification", ErrParse,
 	)
-	// ErrParseWait indicates that the wait specification was not valid.
+	// ErrExpectedWait indicates that the wait specification was not valid.
 	ErrExpectedWait = fmt.Errorf(
 		"%w: expected wait specification", ErrParse,
+	)
+	// ErrExpectedRetry indicates that the retry specification was not valid.
+	ErrExpectedRetry = fmt.Errorf(
+		"%w: expected retry specification", ErrParse,
+	)
+	// ErrInvalidRetryAttempts indicates that the retry attempts was not
+	// positive.
+	ErrInvalidRetryAttempts = fmt.Errorf(
+		"%w: invalid retry attempts", ErrParse,
 	)
 	// ErrFileNotFound is returned when a file path does not exist for a
 	// create/apply/delete target.
@@ -155,6 +165,24 @@ func ExpectedWaitAt(node *yaml.Node) error {
 	return fmt.Errorf(
 		"%w at line %d, column %d",
 		ErrExpectedWait, node.Line, node.Column,
+	)
+}
+
+// ExpectedRetryAt returns an ErrExpectedRetry error annotated with the
+// line/column of the supplied YAML node.
+func ExpectedRetryAt(node *yaml.Node) error {
+	return fmt.Errorf(
+		"%w at line %d, column %d",
+		ErrExpectedRetry, node.Line, node.Column,
+	)
+}
+
+// InvalidRetryAttempts returns an ErrInvalidRetryAttempts error annotated with
+// the line/column of the supplied YAML node.
+func InvalidRetryAttempts(node *yaml.Node, attempts int) error {
+	return fmt.Errorf(
+		"%w of %d at line %d, column %d",
+		ErrInvalidRetryAttempts, attempts, node.Line, node.Column,
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/samber/lo v1.38.1

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/plugin/exec/eval.go
+++ b/plugin/exec/eval.go
@@ -31,9 +31,6 @@ func (s *Spec) Eval(ctx context.Context, t *testing.T) *result.Result {
 	}
 	a := newAssertions(s.Assert, ec, outbuf, errbuf)
 	if !a.OK(ctx) {
-		for _, fail := range a.Failures() {
-			t.Error(fail)
-		}
 		if s.On != nil {
 			if s.On.Fail != nil {
 				outbuf.Reset()

--- a/plugin/exec/testdata/on-fail-exec.yaml
+++ b/plugin/exec/testdata/on-fail-exec.yaml
@@ -4,28 +4,7 @@ tests:
   - exec: echo "cat"
     assert:
       out:
-        is: cat
-    # Unfortunately there's not really any good way of testing things like this
-    # except by manually causing an assertion to fail in the test case and checking
-    # to see if the `on.fail` action was taken and debug output emitted to the
-    # console.
-    # 
-    # When I change `assert.out.is` above to "dat" instead of "cat", I get the
-    # correct behaviour:
-    # 
-    # === RUN   TestOnFail
-    # === RUN   TestOnFail/on-fail-exec
-    #     action.go:59: exec: echo [cat]
-    #     eval.go:35: assertion failed: not equal: expected dat but got cat
-    #     action.go:59: exec: echo [bad kitty]
-    #     eval.go:46: on.fail.exec: stdout: bad kitty
-    # === NAME  TestOnFail
-    #     eval_test.go:256:
-    #         	Error Trace:	/home/jaypipes/src/github.com/gdt-dev/gdt/plugin/exec/eval_test.go:256
-    #         	Error:      	Should be false
-    #         	Test:       	TestOnFail
-    # --- FAIL: TestOnFail (0.00s)
-    #     --- FAIL: TestOnFail/on-fail-exec (0.00s)
+        is: dat
     on:
       fail:
         exec: echo "bad kitty"

--- a/scenario/parse_test.go
+++ b/scenario/parse_test.go
@@ -131,6 +131,45 @@ func TestBadTimeoutDurationScenario(t *testing.T) {
 	assert.Nil(s)
 }
 
+func TestBadRetry(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "parse", "fail", "bad-retry.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	s, err := scenario.FromReader(f, scenario.WithPath(fp))
+	assert.ErrorIs(err, errors.ErrExpectedMap)
+	assert.Nil(s)
+}
+
+func TestBadRetryAttempts(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "parse", "fail", "bad-retry-attempts.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	s, err := scenario.FromReader(f, scenario.WithPath(fp))
+	assert.ErrorIs(err, errors.ErrInvalidRetryAttempts)
+	assert.Nil(s)
+}
+
+func TestBadRetryIntervalDuration(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "parse", "fail", "bad-retry-interval-duration.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	s, err := scenario.FromReader(f, scenario.WithPath(fp))
+	assert.ErrorContains(err, "invalid duration")
+	assert.Nil(s)
+}
+
 func TestKnownSpec(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/scenario/run_test.go
+++ b/scenario/run_test.go
@@ -8,7 +8,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"flag"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -18,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var failFlag = flag.Bool("fail", false, "run tests expected to fail")
 
 func TestRun(t *testing.T) {
 	require := require.New(t)
@@ -111,10 +116,37 @@ func TestDebugFlushing(t *testing.T) {
 	require.Contains(debugout, "[gdt] [foo-debug-wait-flush] wait: 250ms before")
 }
 
-func TestTimeoutCascade(t *testing.T) {
+func TestNoRetry(t *testing.T) {
 	require := require.New(t)
 
-	fp := filepath.Join("testdata", "foo-timeout.yaml")
+	fp := filepath.Join("testdata", "no-retry.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	ctx := gdtcontext.New(gdtcontext.WithDebug(w))
+
+	s, err := scenario.FromReader(f, scenario.WithPath(fp))
+	require.Nil(err)
+	require.NotNil(s)
+
+	err = s.Run(ctx, t)
+	require.Nil(err)
+	require.False(t.Failed())
+	w.Flush()
+	require.NotEqual(b.Len(), 0)
+	debugout := b.String()
+	require.Contains(debugout, "[gdt] [no-retry] run: single-shot (no retries) ok: true")
+}
+
+func TestFailRetryTestOverride(t *testing.T) {
+	if !*failFlag {
+		t.Skip("skipping without -fail flag")
+	}
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "retry-test-override.yaml")
 	f, err := os.Open(fp)
 	require.Nil(err)
 
@@ -122,8 +154,26 @@ func TestTimeoutCascade(t *testing.T) {
 	require.Nil(err)
 	require.NotNil(s)
 
-	err = s.Run(context.TODO(), t)
+	ctx := gdtcontext.New(gdtcontext.WithDebug())
+	err = s.Run(ctx, t)
 	require.Nil(err)
+}
+
+func TestRetryTestOverride(t *testing.T) {
+	require := require.New(t)
+	target := os.Args[0]
+	failArgs := []string{
+		"-test.v",
+		"-test.run=FailRetryTestOverride",
+		"-fail",
+	}
+	outerr, err := exec.Command(target, failArgs...).CombinedOutput()
+
+	// The test should have failed...
+	require.NotNil(err)
+
+	debugout := fmt.Sprintf("%s", outerr)
+	require.Contains(debugout, "[gdt] [retry-test-override] run: exceeded max attempts 2. stopping.")
 }
 
 func TestSkipIf(t *testing.T) {

--- a/scenario/scenario.go
+++ b/scenario/scenario.go
@@ -13,6 +13,9 @@ import (
 // Scenario is a generalized gdt test case file. It contains a set of Runnable
 // test units.
 type Scenario struct {
+	// evalPlugins stores the plugin that will evaluate the test spec at a
+	// particular index
+	evalPlugins map[int]gdttypes.Plugin
 	// Path is the filepath to the test case.
 	Path string `yaml:"-"`
 	// Name is the short name for the test case. If empty, defaults to the base

--- a/scenario/stub_plugins_test.go
+++ b/scenario/stub_plugins_test.go
@@ -238,6 +238,9 @@ func (s *fooSpec) Eval(ctx context.Context, t *testing.T) *result.Result {
 			fails = append(fails, fail)
 		}
 	})
+	for _, fail := range fails {
+		t.Error(fail)
+	}
 	return result.New(result.WithFailures(fails...))
 }
 

--- a/scenario/testdata/no-retry.yaml
+++ b/scenario/testdata/no-retry.yaml
@@ -1,0 +1,6 @@
+name: no-retry
+description: a scenario using a plugin with no retries
+tests:
+  # The foo plugin does not use retries
+  - foo: bar
+    name: bar

--- a/scenario/testdata/parse/fail/bad-retry-attempts.yaml
+++ b/scenario/testdata/parse/fail/bad-retry-attempts.yaml
@@ -1,0 +1,6 @@
+name: bad-retry-attempts
+description: a scenario with an invalid retry attempts
+tests:
+  - foo: baz
+    retry:
+      attempts: -1

--- a/scenario/testdata/parse/fail/bad-retry-interval-duration.yaml
+++ b/scenario/testdata/parse/fail/bad-retry-interval-duration.yaml
@@ -1,0 +1,6 @@
+name: bad-retry-interval-duration
+description: a scenario with an invalid duration string in a spec retry interval
+tests:
+  - foo: baz
+    retry:
+      interval: notaduration

--- a/scenario/testdata/parse/fail/bad-retry.yaml
+++ b/scenario/testdata/parse/fail/bad-retry.yaml
@@ -1,0 +1,5 @@
+name: bad-retry
+description: a scenario with an invalid retry spec
+tests:
+  - foo: baz
+    retry: notaretry

--- a/scenario/testdata/retry-test-override.yaml
+++ b/scenario/testdata/retry-test-override.yaml
@@ -1,0 +1,9 @@
+name: retry-test-override
+description: a scenario using a test spec override for a retry
+tests:
+  # The foo plugin fails if foo == bar but name != bar
+  - foo: bar
+    name: baz
+    retry:
+      attempts: 2
+      interval: .25s

--- a/types/plugin.go
+++ b/types/plugin.go
@@ -15,6 +15,9 @@ type PluginInfo struct {
 	Aliases []string
 	// Description describes what types of tests the plugin can handle.
 	Description string
+	// Retry is a Retry that should be used by default for test specs of this
+	// plugin.
+	Retry *Retry
 }
 
 // Plugin is the driver interface for different types of gdt tests.

--- a/types/retry.go
+++ b/types/retry.go
@@ -1,0 +1,46 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package types
+
+import (
+	"time"
+)
+
+const (
+	// DefaultRetryAttempts indicates the default number of times to retry
+	// retries when the plugin uses retries but has not specified a number of
+	// attempts.
+	DefaultRetryAttempts = 3 * time.Second
+	// DefaultRetryConstantInterval indicates the default interval to use for
+	// retries when the plugin uses retries but does not use exponential
+	// backoff.
+	DefaultRetryConstantInterval = 3 * time.Second
+)
+
+// Retry contains information about the number of attempts and interval
+// duration with which a Plugin should re-run a Spec's action if the Spec's
+// assertions fail.
+type Retry struct {
+	// Attempts is the number of  times that the test unit should be retried in
+	// the event of assertion failure.
+	Attempts *int `yaml:"attempts,omitempty"`
+	// Interval is the amount of time that the plugin should wait before
+	// retrying the test unit in the event of assertion failure.
+	// Specify a duration using Go's time duration string.
+	// See https://pkg.go.dev/time#ParseDuration
+	Interval string `yaml:"interval,omitempty"`
+	// Exponential indicates that an exponential backoff should be applied to
+	// the retry. When true, the value of Interval, if any, is used as the
+	// initial interval for the backoff algoritm.
+	Exponential bool `yaml:"exponential,omitempty"`
+}
+
+// IntervalDuration returns the time duration of the Retry.Interval
+func (r *Retry) IntervalDuration() time.Duration {
+	// Parsing already validated the duration string so no need to check again
+	// here
+	dur, _ := time.ParseDuration(r.Interval)
+	return dur
+}


### PR DESCRIPTION
Adds the ability to configure retry behaviour for any test spec, using either a constant interval or an exponential backoff.

In doing so, reworks the framework to have all calls to testing.T.Errorf() happen in the Scenario.Run() method, as well as have that method handle all retries. gdt-kube will need to be refactored to remove the retry behaviour implemented in that plugin.

Also, this finally fixes the way that failures are tested by using the strategy outlined in https://github.com/golang/go/issues/39903.

Issue #26