### PR TITLE
allow plugin-defaulted timeout values

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,12 +458,8 @@ All test specs have the following fields:
 
 * `name`: (optional) string describing the test unit.
 * `description`: (optional) string with longer description of the test unit.
-* `timeout`: (optional) an object containing [timeout information][timeout] for the test
-  unit.
-* `timeout.after`: a string duration of time the test unit is expected to
+* `timeout`: (optional) a string duration of time the test unit is expected to
   complete within.
-* `timeout.expected`: a bool indicating that the test unit is expected to not
-  complete before `timeout.after`. This is really only useful in unit testing.
 * `retry`: (optional) an object containing retry configurationu for the test
   unit. Some plugins will automatically attempt to retry the test action when
   an assertion fails. This field allows you to control this retry behaviour for
@@ -497,7 +493,6 @@ All test specs have the following fields:
 [exec-plugin]: https://github.com/gdt-dev/gdt/tree/ecee17249e1fa10147cf9191be0358923da44094/plugin/exec
 [http-plugin]: https://github.com/gdt-dev/http
 [kube-plugin]: https://github.com/gdt-dev/kube
-[timeout]: https://github.com/gdt-dev/gdt/blob/2791e11105fd3c36d1f11a7d111e089be7cdc84c/types/timeout.go#L11-L22
 [wait]: https://github.com/gdt-dev/gdt/blob/2791e11105fd3c36d1f11a7d111e089be7cdc84c/types/wait.go#L11-L25
 
 #### `exec` test spec structure

--- a/plugin/exec/plugin.go
+++ b/plugin/exec/plugin.go
@@ -11,6 +11,15 @@ import (
 	gdttypes "github.com/gdt-dev/gdt/types"
 )
 
+var (
+	DefaultTimeout = "10s"
+)
+
+// OverrideDefaultTimeout is only used in testing...
+func OverrideDefaultTimeout(d string) {
+	DefaultTimeout = d
+}
+
 func init() {
 	gdtplugin.Register(Plugin())
 }
@@ -24,6 +33,9 @@ type plugin struct{}
 func (p *plugin) Info() gdttypes.PluginInfo {
 	return gdttypes.PluginInfo{
 		Name: pluginName,
+		Timeout: &gdttypes.Timeout{
+			After: DefaultTimeout,
+		},
 	}
 }
 

--- a/plugin/exec/testdata/sleep-timeout.yaml
+++ b/plugin/exec/testdata/sleep-timeout.yaml
@@ -7,4 +7,3 @@ tests:
   - exec: sleep 5
     timeout:
       after: 50ms
-      expected: true

--- a/plugin/exec/testdata/timeout-cascade.yaml
+++ b/plugin/exec/testdata/timeout-cascade.yaml
@@ -10,4 +10,3 @@ tests:
     exec: sleep .25
     timeout:
       after: 20ms
-      expected: true

--- a/plugin/exec/testdata/timeout-plugin-default.yaml
+++ b/plugin/exec/testdata/timeout-plugin-default.yaml
@@ -1,0 +1,5 @@
+name: timeout-plugin-default
+description: a scenario that tests the plugin default timeout
+tests:
+  - name: uses plugin default timeout
+    exec: sleep 1

--- a/scenario/parse_test.go
+++ b/scenario/parse_test.go
@@ -92,6 +92,18 @@ func TestUnknownSpec(t *testing.T) {
 	assert.Nil(s)
 }
 
+func TestTimeoutScalarOrMap(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "parse", "timeout-scalar-or-map.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	_, err = scenario.FromReader(f, scenario.WithPath(fp))
+	assert.Nil(err)
+}
+
 func TestBadTimeout(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -101,7 +113,7 @@ func TestBadTimeout(t *testing.T) {
 	require.Nil(err)
 
 	s, err := scenario.FromReader(f, scenario.WithPath(fp))
-	assert.ErrorIs(err, errors.ErrExpectedMap)
+	assert.ErrorIs(err, errors.ErrExpectedScalarOrMap)
 	assert.Nil(s)
 }
 

--- a/scenario/testdata/parse/fail/bad-timeout.yaml
+++ b/scenario/testdata/parse/fail/bad-timeout.yaml
@@ -2,4 +2,5 @@ name: bad-timeout
 description: a scenario with an invalid timeout spec
 tests:
   - foo: baz
-    timeout: notatimeout
+    timeout:
+      - one

--- a/scenario/testdata/parse/timeout-scalar-or-map.yaml
+++ b/scenario/testdata/parse/timeout-scalar-or-map.yaml
@@ -1,0 +1,8 @@
+name: timeout-scalar-or-map
+description: a scenario with both scalar and object timeout spec
+tests:
+  - foo: baz
+    timeout: 1s
+  - foo: bar
+    timeout:
+      after: 1s

--- a/types/plugin.go
+++ b/types/plugin.go
@@ -15,6 +15,9 @@ type PluginInfo struct {
 	Aliases []string
 	// Description describes what types of tests the plugin can handle.
 	Description string
+	// Timeout is a Timeout that should be used by default for test specs of
+	// this plugin.
+	Timeout *Timeout
 	// Retry is a Retry that should be used by default for test specs of this
 	// plugin.
 	Retry *Retry

--- a/types/timeout.go
+++ b/types/timeout.go
@@ -16,9 +16,6 @@ type Timeout struct {
 	// Specify a duration using Go's time duration string.
 	// See https://pkg.go.dev/time#ParseDuration
 	After string `yaml:"after,omitempty"`
-	// Expected indicates whether the timeout is expected to be exceeded. This
-	// is mostly useful for unit testing of the timeout functionality itself.
-	Expected bool `yaml:"expected,omitempty"`
 }
 
 // Duration returns the time duration of the Timeout


### PR DESCRIPTION
Allows plugins to specify their own default timeout values. In addition, removes the `timeout.expected` flag which was only a crutch for before we figured out how to test assertion failures in a clean manner.