### PR TITLE
simplify Evaluable interface and Scenario.Run

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -43,8 +43,8 @@ func (s *fooSpec) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func (s *fooSpec) Eval(ctx context.Context, t *testing.T) *result.Result {
-	return nil
+func (s *fooSpec) Eval(ctx context.Context) (*result.Result, error) {
+	return nil, nil
 }
 
 type fooPlugin struct{}

--- a/plugin/exec/action.go
+++ b/plugin/exec/action.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"os/exec"
-	"testing"
 
 	gdtcontext "github.com/gdt-dev/gdt/context"
 	"github.com/gdt-dev/gdt/debug"
@@ -38,7 +37,6 @@ type Action struct {
 // respectively.
 func (a *Action) Do(
 	ctx context.Context,
-	t *testing.T,
 	outbuf *bytes.Buffer,
 	errbuf *bytes.Buffer,
 	exitcode *int,

--- a/plugin/exec/eval.go
+++ b/plugin/exec/eval.go
@@ -7,7 +7,6 @@ package exec
 import (
 	"bytes"
 	"context"
-	"testing"
 
 	"github.com/gdt-dev/gdt/debug"
 	gdterrors "github.com/gdt-dev/gdt/errors"
@@ -17,17 +16,21 @@ import (
 // Eval performs an action and evaluates the results of that action, returning
 // a Result that informs the Scenario about what failed or succeeded about the
 // Evaluable's conditions.
-func (s *Spec) Eval(ctx context.Context, t *testing.T) *result.Result {
+//
+// Errors returned by Eval() are **RuntimeErrors**, not failures in assertions.
+func (s *Spec) Eval(
+	ctx context.Context,
+) (*result.Result, error) {
 	outbuf := &bytes.Buffer{}
 	errbuf := &bytes.Buffer{}
 
 	var ec int
 
-	if err := s.Do(ctx, t, outbuf, errbuf, &ec); err != nil {
+	if err := s.Do(ctx, outbuf, errbuf, &ec); err != nil {
 		if err == gdterrors.ErrTimeoutExceeded {
-			return result.New(result.WithFailures(gdterrors.ErrTimeoutExceeded))
+			return result.New(result.WithFailures(gdterrors.ErrTimeoutExceeded)), nil
 		}
-		return result.New(result.WithRuntimeError(ExecRuntimeError(err)))
+		return nil, ExecRuntimeError(err)
 	}
 	a := newAssertions(s.Assert, ec, outbuf, errbuf)
 	if !a.OK(ctx) {
@@ -35,12 +38,12 @@ func (s *Spec) Eval(ctx context.Context, t *testing.T) *result.Result {
 			if s.On.Fail != nil {
 				outbuf.Reset()
 				errbuf.Reset()
-				err := s.On.Fail.Do(ctx, t, outbuf, errbuf, nil)
+				err := s.On.Fail.Do(ctx, outbuf, errbuf, nil)
 				if err != nil {
 					debug.Println(ctx, "error in on.fail.exec: %s", err)
 				}
 			}
 		}
 	}
-	return result.New(result.WithFailures(a.Failures()...))
+	return result.New(result.WithFailures(a.Failures()...)), nil
 }

--- a/plugin/registry_test.go
+++ b/plugin/registry_test.go
@@ -36,8 +36,8 @@ func (s *fooSpec) Base() *gdttypes.Spec {
 	return &s.Spec
 }
 
-func (s *fooSpec) Eval(context.Context, *testing.T) *result.Result {
-	return nil
+func (s *fooSpec) Eval(context.Context) (*result.Result, error) {
+	return nil, nil
 }
 
 func (s *fooSpec) UnmarshalYAML(node *yaml.Node) error {

--- a/result/result.go
+++ b/result/result.go
@@ -4,13 +4,6 @@
 
 package result
 
-import (
-	"errors"
-	"fmt"
-
-	gdterrors "github.com/gdt-dev/gdt/errors"
-)
-
 // Result is returned from a `Evaluable.Eval` execution. It serves two
 // purposes:
 //
@@ -23,9 +16,6 @@ import (
 // returned in the Result and the `Scenario.Run` method injects that
 // information into the context that is supplied to the next Spec's `Run`.
 type Result struct {
-	// err is any error that was returned from the Evaluable's execution. This
-	// is guaranteed to be a `gdterrors.RuntimeError`.
-	err error
 	// failures is the collection of error messages from assertion failures
 	// that occurred during Eval(). These are *not* `gdterrors.RuntimeError`.
 	failures []error
@@ -34,17 +24,6 @@ type Result struct {
 	// the `gdtcontext.PriorRunData()` function. Plugins are responsible for
 	// clearing and setting any used prior run data.
 	data map[string]interface{}
-}
-
-// HasRuntimeError returns true if the Eval() returned a runtime error, false
-// otherwise.
-func (r *Result) HasRuntimeError() bool {
-	return r.err != nil
-}
-
-// RuntimeError returns the runtime error
-func (r *Result) RuntimeError() error {
-	return r.err
 }
 
 // HasData returns true if any of the run data has been set, false otherwise.
@@ -85,19 +64,6 @@ func (r *Result) SetFailures(failures ...error) {
 }
 
 type ResultModifier func(*Result)
-
-// WithRuntimeError modifies the Result with the supplied error
-func WithRuntimeError(err error) ResultModifier {
-	if !errors.Is(err, gdterrors.RuntimeError) {
-		msg := fmt.Sprintf("expected %s to be a gdterrors.RuntimeError", err)
-		// panic here because a plugin author incorrectly implemented their
-		// plugin Spec's Eval() method...
-		panic(msg)
-	}
-	return func(r *Result) {
-		r.err = err
-	}
-}
 
 // WithData modifies the Result with the supplied run data key and value
 func WithData(key string, val interface{}) ResultModifier {

--- a/scenario/run_test.go
+++ b/scenario/run_test.go
@@ -137,7 +137,7 @@ func TestNoRetry(t *testing.T) {
 	w.Flush()
 	require.NotEqual(b.Len(), 0)
 	debugout := b.String()
-	require.Contains(debugout, "[gdt] [no-retry] run: single-shot (no retries) ok: true")
+	require.Contains(debugout, "[gdt] [no-retry/0:bar] run: single-shot (no retries) ok: true")
 }
 
 func TestFailRetryTestOverride(t *testing.T) {
@@ -173,7 +173,7 @@ func TestRetryTestOverride(t *testing.T) {
 	require.NotNil(err)
 
 	debugout := string(outerr)
-	require.Contains(debugout, "[gdt] [retry-test-override] run: exceeded max attempts 2. stopping.")
+	require.Contains(debugout, "[gdt] [retry-test-override/0:baz] run: exceeded max attempts 2. stopping.")
 }
 
 func TestSkipIf(t *testing.T) {

--- a/types/evaluable.go
+++ b/types/evaluable.go
@@ -6,7 +6,6 @@ package types
 
 import (
 	"context"
-	"testing"
 
 	"github.com/gdt-dev/gdt/result"
 )
@@ -16,7 +15,10 @@ type Evaluable interface {
 	// Eval performs an action and evaluates the results of that action,
 	// returning a Result that informs the Scenario about what failed or
 	// succeeded about the Evaluable's conditions.
-	Eval(context.Context, *testing.T) *result.Result
+	//
+	// Errors returned by Eval() are **RuntimeErrors**, not failures in
+	// assertions.
+	Eval(context.Context) (*result.Result, error)
 	// SetBase sets the Evaluable's base Spec
 	SetBase(Spec)
 	// Base returns the Evaluable's base Spec


### PR DESCRIPTION
No longer pass the `*testing.T` down into Plugin's Spec.Eval() method, freeing up plugins to focus on actions and assertions. Scenario.Run() now handles the `*testing.T` and the trace context centrally instead of plugins needing to do this.

Also simplifies the Scenario.Run() interface and Evaluable.Eval() interfaces to return (result.Result, error) to more cleanly pass back RuntimeErrors instead of needing a Result.RuntimeError() method.