### PR TITLE
allow an Evaluable to override retry behaviour

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -39,6 +39,14 @@ func (s *fooSpec) Base() *gdttypes.Spec {
 	return &s.Spec
 }
 
+func (s *fooSpec) Retry() *gdttypes.Retry {
+	return nil
+}
+
+func (s *fooSpec) Timeout() *gdttypes.Timeout {
+	return nil
+}
+
 func (s *fooSpec) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }

--- a/plugin/exec/spec.go
+++ b/plugin/exec/spec.go
@@ -26,3 +26,11 @@ func (s *Spec) SetBase(b gdttypes.Spec) {
 func (s *Spec) Base() *gdttypes.Spec {
 	return &s.Spec
 }
+
+func (s *Spec) Retry() *gdttypes.Retry {
+	return nil
+}
+
+func (s *Spec) Timeout() *gdttypes.Timeout {
+	return nil
+}

--- a/plugin/registry_test.go
+++ b/plugin/registry_test.go
@@ -36,6 +36,14 @@ func (s *fooSpec) Base() *gdttypes.Spec {
 	return &s.Spec
 }
 
+func (s *fooSpec) Retry() *gdttypes.Retry {
+	return nil
+}
+
+func (s *fooSpec) Timeout() *gdttypes.Timeout {
+	return nil
+}
+
 func (s *fooSpec) Eval(context.Context) (*result.Result, error) {
 	return nil, nil
 }

--- a/scenario/run_test.go
+++ b/scenario/run_test.go
@@ -140,6 +140,30 @@ func TestNoRetry(t *testing.T) {
 	require.Contains(debugout, "[gdt] [no-retry/0:bar] run: single-shot (no retries) ok: true")
 }
 
+func TestNoRetryEvaluableOverride(t *testing.T) {
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "no-retry-evaluable-override.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	ctx := gdtcontext.New(gdtcontext.WithDebug(w))
+
+	s, err := scenario.FromReader(f, scenario.WithPath(fp))
+	require.Nil(err)
+	require.NotNil(s)
+
+	err = s.Run(ctx, t)
+	require.Nil(err)
+	require.False(t.Failed())
+	w.Flush()
+	require.NotEqual(b.Len(), 0)
+	debugout := b.String()
+	require.Contains(debugout, "[gdt] [no-retry-evaluable-override/0:bar] run: single-shot (no retries) ok: true")
+}
+
 func TestFailRetryTestOverride(t *testing.T) {
 	if !*failFlag {
 		t.Skip("skipping without -fail flag")

--- a/scenario/stub_plugins_test.go
+++ b/scenario/stub_plugins_test.go
@@ -82,6 +82,14 @@ func (s *failSpec) Base() *gdttypes.Spec {
 	return &s.Spec
 }
 
+func (s *failSpec) Retry() *gdttypes.Retry {
+	return nil
+}
+
+func (s *failSpec) Timeout() *gdttypes.Timeout {
+	return nil
+}
+
 func (s *failSpec) Eval(context.Context) (*result.Result, error) {
 	return nil, fmt.Errorf("%w: Indy, bad dates!", gdterrors.RuntimeError)
 }
@@ -185,6 +193,14 @@ func (s *fooSpec) Base() *gdttypes.Spec {
 	return &s.Spec
 }
 
+func (s *fooSpec) Retry() *gdttypes.Retry {
+	return nil
+}
+
+func (s *fooSpec) Timeout() *gdttypes.Timeout {
+	return nil
+}
+
 func (s *fooSpec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return errors.ExpectedMapAt(node)
@@ -266,6 +282,14 @@ func (s *barSpec) Base() *gdttypes.Spec {
 	return &s.Spec
 }
 
+func (s *barSpec) Retry() *gdttypes.Retry {
+	return gdttypes.NoRetry
+}
+
+func (s *barSpec) Timeout() *gdttypes.Timeout {
+	return nil
+}
+
 func (s *barSpec) Eval(context.Context) (*result.Result, error) {
 	return result.New(), nil
 }
@@ -339,6 +363,14 @@ func (s *priorRunSpec) SetBase(b gdttypes.Spec) {
 
 func (s *priorRunSpec) Base() *gdttypes.Spec {
 	return &s.Spec
+}
+
+func (s *priorRunSpec) Retry() *gdttypes.Retry {
+	return nil
+}
+
+func (s *priorRunSpec) Timeout() *gdttypes.Timeout {
+	return nil
 }
 
 func (s *priorRunSpec) UnmarshalYAML(node *yaml.Node) error {

--- a/scenario/testdata/no-retry-evaluable-override.yaml
+++ b/scenario/testdata/no-retry-evaluable-override.yaml
@@ -1,0 +1,6 @@
+name: no-retry-evaluable-override
+description: a scenario using a plugin with an evaluable override for no retries
+tests:
+  # The bar plugin's Evaluable has a NoRetry override
+  - bar: 42
+    name: bar

--- a/types/evaluable.go
+++ b/types/evaluable.go
@@ -23,4 +23,8 @@ type Evaluable interface {
 	SetBase(Spec)
 	// Base returns the Evaluable's base Spec
 	Base() *Spec
+	// Retry returns the Evaluable's Retry override, if any
+	Retry() *Retry
+	// Timeout returns the Evaluable's Timeout override, if any
+	Timeout() *Timeout
 }

--- a/types/retry.go
+++ b/types/retry.go
@@ -19,6 +19,12 @@ const (
 	DefaultRetryConstantInterval = 3 * time.Second
 )
 
+var (
+	// NoRetry indicates that there should not be any retry attempts. It is
+	// passed from a plugin to indicate a Spec should not be retried.
+	NoRetry = &Retry{}
+)
+
 // Retry contains information about the number of attempts and interval
 // duration with which a Plugin should re-run a Spec's action if the Spec's
 // assertions fail.


### PR DESCRIPTION
We need to allow a plugin's Evaluable to override the plugin's default retry behaviour. In the case of gdt-kube, we want to *not* retry in the case of `kubectl.create`, `kubectl.apply` and `kubectl.delete`, however we *do* want to retry in the case of `kubectl.get`...

Issue gdt-dev/kube#17