### PR TITLE
pull PushTrace up into main spec loop

### DIFF
--- a/scenario/run_test.go
+++ b/scenario/run_test.go
@@ -113,7 +113,7 @@ func TestDebugFlushing(t *testing.T) {
 	w.Flush()
 	require.NotEqual(b.Len(), 0)
 	debugout := b.String()
-	require.Contains(debugout, "[gdt] [foo-debug-wait-flush] wait: 250ms before")
+	require.Contains(debugout, "[gdt] [foo-debug-wait-flush/0:bar] wait: 250ms before")
 }
 
 func TestNoRetry(t *testing.T) {


### PR DESCRIPTION
In order to have the wait debug messages have the appropriate context prefix, moves the PushTrace up into the main loop over specs.