### PR TITLE
remove Scenario.evalPlugins

### DIFF
--- a/api/spec.go
+++ b/api/spec.go
@@ -28,6 +28,8 @@ var (
 // output or behaviour. All gdt plugins have their own Spec structs that
 // inherit from this base struct.
 type Spec struct {
+	// Plugin is a pointer to the plugin that successfully parsed the test spec
+	Plugin Plugin `yaml:"-"`
 	// Defaults contains the parsed defaults for the Spec. These are injected
 	// by the scenario during parse.
 	Defaults *Defaults `yaml:"-"`

--- a/internal/testutil/plugin/bar/plugin.go
+++ b/internal/testutil/plugin/bar/plugin.go
@@ -14,8 +14,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var (
+	// this is just for testing purposes...
+	PluginRef = &Plugin{}
+)
+
 func init() {
-	plugin.Register(&Plugin{})
+	plugin.Register(PluginRef)
 }
 
 type Defaults struct {

--- a/internal/testutil/plugin/foo/plugin.go
+++ b/internal/testutil/plugin/foo/plugin.go
@@ -15,8 +15,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var (
+	// this is just for testing purposes...
+	PluginRef = &Plugin{}
+)
+
 func init() {
-	plugin.Register(&Plugin{})
+	plugin.Register(PluginRef)
 }
 
 type InnerDefaults struct {

--- a/plugin/exec/parse_test.go
+++ b/plugin/exec/parse_test.go
@@ -53,6 +53,7 @@ func TestSimpleCommand(t *testing.T) {
 	expTests := []api.Evaluable{
 		&gdtexec.Spec{
 			Spec: api.Spec{
+				Plugin:   gdtexec.PluginRef,
 				Index:    0,
 				Defaults: &api.Defaults{},
 			},

--- a/plugin/exec/plugin.go
+++ b/plugin/exec/plugin.go
@@ -12,16 +12,21 @@ import (
 )
 
 var (
+	// this is just for testing purposes...
+	PluginRef = &plugin{}
+)
+
+func init() {
+	gdtplugin.Register(PluginRef)
+}
+
+var (
 	DefaultTimeout = "10s"
 )
 
 // OverrideDefaultTimeout is only used in testing...
 func OverrideDefaultTimeout(d string) {
 	DefaultTimeout = d
-}
-
-func init() {
-	gdtplugin.Register(Plugin())
 }
 
 const (

--- a/scenario/parse.go
+++ b/scenario/parse.go
@@ -82,8 +82,6 @@ func (s *Scenario) UnmarshalYAML(node *yaml.Node) error {
 			s.Defaults = defaults
 		}
 	}
-	// We store a lookup to the parsing plugin for each parsed test spec
-	evalPlugins := map[int]api.Plugin{}
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if keyNode.Kind != yaml.ScalarNode {
@@ -116,10 +114,10 @@ func (s *Scenario) UnmarshalYAML(node *yaml.Node) error {
 							}
 							return err
 						}
+						base.Plugin = plugin
 						sp.SetBase(base)
 						s.Tests = append(s.Tests, sp)
 						parsed = true
-						evalPlugins[idx] = plugin
 						break
 					}
 				}
@@ -161,6 +159,5 @@ func (s *Scenario) UnmarshalYAML(node *yaml.Node) error {
 			}
 		}
 	}
-	s.evalPlugins = evalPlugins
 	return nil
 }

--- a/scenario/parse_test.go
+++ b/scenario/parse_test.go
@@ -236,6 +236,7 @@ func TestKnownSpec(t *testing.T) {
 	expTests := []api.Evaluable{
 		&foo.Spec{
 			Spec: api.Spec{
+				Plugin:   foo.PluginRef,
 				Index:    0,
 				Name:     "bar",
 				Defaults: expSpecDefaults,
@@ -244,6 +245,7 @@ func TestKnownSpec(t *testing.T) {
 		},
 		&foo.Spec{
 			Spec: api.Spec{
+				Plugin:      foo.PluginRef,
 				Index:       1,
 				Description: "Bazzy Bizzy",
 				Defaults:    expSpecDefaults,
@@ -272,6 +274,7 @@ func TestMultipleSpec(t *testing.T) {
 	expTests := []api.Evaluable{
 		&foo.Spec{
 			Spec: api.Spec{
+				Plugin:   foo.PluginRef,
 				Index:    0,
 				Defaults: &api.Defaults{},
 			},
@@ -279,6 +282,7 @@ func TestMultipleSpec(t *testing.T) {
 		},
 		&bar.Spec{
 			Spec: api.Spec{
+				Plugin:   bar.PluginRef,
 				Index:    1,
 				Defaults: &api.Defaults{},
 			},
@@ -340,6 +344,7 @@ func TestEnvExpansion(t *testing.T) {
 	expTests := []api.Evaluable{
 		&foo.Spec{
 			Spec: api.Spec{
+				Plugin:   foo.PluginRef,
 				Index:    0,
 				Name:     "$NOT_EXPANDED",
 				Defaults: expSpecDefaults,
@@ -348,6 +353,7 @@ func TestEnvExpansion(t *testing.T) {
 		},
 		&foo.Spec{
 			Spec: api.Spec{
+				Plugin:      foo.PluginRef,
 				Index:       1,
 				Description: "Bazzy Bizzy",
 				Defaults:    expSpecDefaults,
@@ -406,6 +412,7 @@ func TestScenarioDefaults(t *testing.T) {
 	expTests := []api.Evaluable{
 		&foo.Spec{
 			Spec: api.Spec{
+				Plugin:   foo.PluginRef,
 				Index:    0,
 				Defaults: expSpecDefaults,
 				Timeout: &api.Timeout{
@@ -416,6 +423,7 @@ func TestScenarioDefaults(t *testing.T) {
 		},
 		&foo.Spec{
 			Spec: api.Spec{
+				Plugin:   foo.PluginRef,
 				Index:    1,
 				Defaults: expSpecDefaults,
 			},


### PR DESCRIPTION
Adds a new `Spec.Plugin` field and stores a pointer to the plugin that successfully parsed the test spec.