### PR TITLE
fix TimeoutConflict error message

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -315,27 +315,31 @@ func RequiredFixtureMissing(name string) error {
 func TimeoutConflict(
 	ti *Timings,
 ) error {
-	gotestDeadline := ti.GoTestTimeout
+	goTestTimeout := ti.GoTestTimeout
 	totalWait := ti.TotalWait
 	maxTimeout := ti.MaxTimeout
 	msg := fmt.Sprintf(
 		"go test -timeout value of %s ",
-		(gotestDeadline + time.Second).Round(time.Second),
+		(goTestTimeout + time.Second).Round(time.Second),
 	)
 	if totalWait > 0 {
-		msg += fmt.Sprintf(
-			"is shorter than the total wait time in the scenario: %s. "+
-				"either decrease the wait times or increase the "+
-				"go test -timeout value.",
-			totalWait.Round(time.Second),
-		)
+		if totalWait.Abs() > goTestTimeout.Abs() {
+			msg += fmt.Sprintf(
+				"is shorter than the total wait time in the scenario: %s. "+
+					"either decrease the wait times or increase the "+
+					"go test -timeout value.",
+				totalWait.Round(time.Second),
+			)
+		}
 	} else {
-		msg += fmt.Sprintf(
-			"is shorter than the maximum timeout specified in the "+
-				"scenario: %s. either decrease the scenario or spec "+
-				"timeout or increase the go test -timeout value.",
-			maxTimeout.Round(time.Second),
-		)
+		if maxTimeout.Abs() > goTestTimeout.Abs() {
+			msg += fmt.Sprintf(
+				"is shorter than the maximum timeout specified in the "+
+					"scenario: %s. either decrease the scenario or spec "+
+					"timeout or increase the go test -timeout value.",
+				maxTimeout.Round(time.Second),
+			)
+		}
 	}
 	return fmt.Errorf("%w: %s", ErrTimeoutConflict, msg)
 }


### PR DESCRIPTION
The TimeoutConflict error message was not accurately showing the conflict if both the wait total and max timeout values were non-zero.