### PR TITLE
correct exit code assertion in exec plugin

### DIFF
--- a/.github/workflows/fmtcheck.yml
+++ b/.github/workflows/fmtcheck.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - name: harden runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
        with:
          egress-policy: block
          disable-sudo: true
@@ -26,8 +26,9 @@ jobs:
            raw.githubusercontent.com:443
            objects.githubusercontent.com:443
            proxy.golang.org:443
+           blob.core.windows.net:443
      - name: checkout code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
      - name: setup go
        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
        with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
            raw.githubusercontent.com:443
            objects.githubusercontent.com:443
            proxy.golang.org:443
+           blob.core.windows.net:443
      - name: checkout code
        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
      - name: setup go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
      - name: harden runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
        with:
          egress-policy: block
          disable-sudo: true
@@ -29,8 +29,9 @@ jobs:
            raw.githubusercontent.com:443
            objects.githubusercontent.com:443
            proxy.golang.org:443
+           blob.core.windows.net:443
      - name: checkout code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
      - name: setup go
        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
        with:

--- a/plugin/exec/assertions.go
+++ b/plugin/exec/assertions.go
@@ -166,9 +166,13 @@ func newAssertions(
 	outPipe *bytes.Buffer,
 	errPipe *bytes.Buffer,
 ) api.Assertions {
+	expExitCode := 0
+	if e != nil {
+		expExitCode = e.ExitCode
+	}
 	a := &assertions{
 		failures:    []error{},
-		expExitCode: exitCode,
+		expExitCode: expExitCode,
 		exitCode:    exitCode,
 	}
 	if e != nil {

--- a/plugin/exec/testdata/ls-fail-no-exit-code.yaml
+++ b/plugin/exec/testdata/ls-fail-no-exit-code.yaml
@@ -1,0 +1,4 @@
+name: ls-fail-no-exit-code
+description: a scenario that runs the `ls` command with a non-0 exit code and no assertion on exit code
+tests:
+  - exec: ls /this/dir/does/not/exist


### PR DESCRIPTION
The constructor for assertions in the exec plugin was incorrectly setting the expected exit code equal to the exit code it received from the test spec, resulting in script or command executions returning non-0 exit codes from causing a test.FailNow().