### PR TITLE
add variable save/restore for exec plugin

### DIFF
--- a/plugin/exec/action.go
+++ b/plugin/exec/action.go
@@ -13,6 +13,7 @@ import (
 	gdtcontext "github.com/gdt-dev/gdt/context"
 	"github.com/gdt-dev/gdt/debug"
 	"github.com/google/shlex"
+	"github.com/samber/lo"
 )
 
 // Action describes a single execution of one or more commands via the
@@ -29,6 +30,12 @@ type Action struct {
 	// (the default), no shell is used to execute the command and instead the
 	// operating system's `exec` family of calls is used.
 	Shell string `yaml:"shell,omitempty"`
+	// VarStdout is a shortcut for Var:{VARIABLE_NAME}:from:stdout
+	VarStdout string `yaml:"var-stdout,omitempty"`
+	// VarStderr is a shortcut for Var:{VARIABLE_NAME}:from:stderr
+	VarStderr string `yaml:"var-stderr,omitempty"`
+	// VarRC is a shortcut for Var:{VARIABLE_NAME}:from:returncode
+	VarRC string `yaml:"var-rc,omitempty"`
 }
 
 // Do performs a single command or shell execution returning the corresponding
@@ -37,6 +44,7 @@ type Action struct {
 // respectively.
 func (a *Action) Do(
 	ctx context.Context,
+	vars Variables,
 	outbuf *bytes.Buffer,
 	errbuf *bytes.Buffer,
 	exitcode *int,
@@ -53,6 +61,11 @@ func (a *Action) Do(
 		target = a.Shell
 		args = []string{"-c", a.Exec}
 	}
+
+	target = vars.Replace(ctx, target)
+	args = lo.Map(args, func(arg string, _ int) string {
+		return vars.Replace(ctx, arg)
+	})
 
 	debug.Println(ctx, "exec: %s %s", target, args)
 

--- a/plugin/exec/assertions.go
+++ b/plugin/exec/assertions.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gdt-dev/gdt/api"
+	"github.com/samber/lo"
 )
 
 // Expect contains the assertions about an Exec Spec's actions
@@ -40,6 +41,7 @@ type PipeExpect struct {
 // pipeAssertions contains assertions about the contents of a pipe
 type pipeAssertions struct {
 	PipeExpect
+	vars Variables
 	// pipe is the contents of the pipe that we will evaluate.
 	pipe *bytes.Buffer
 	// name is the string name of the pipe.
@@ -74,6 +76,9 @@ func (a *pipeAssertions) OK(ctx context.Context) bool {
 		// When there is just a single value, we use the NotEqual error,
 		// otherwise we use the NotIn error
 		vals := a.ContainsAll.Values()
+		vals = lo.Map(vals, func(val string, _ int) string {
+			return a.vars.Replace(ctx, val)
+		})
 		if len(vals) == 1 {
 			if !strings.Contains(contents, vals[0]) {
 				a.Fail(api.NotEqual(vals[0], contents))
@@ -90,19 +95,27 @@ func (a *pipeAssertions) OK(ctx context.Context) bool {
 	}
 	if a.ContainsAny != nil {
 		found := false
-		for _, find := range a.ContainsAny.Values() {
+		vals := a.ContainsAny.Values()
+		vals = lo.Map(vals, func(val string, _ int) string {
+			return a.vars.Replace(ctx, val)
+		})
+		for _, find := range vals {
 			if idx := strings.Index(contents, find); idx > -1 {
 				found = true
 				break
 			}
 		}
 		if !found {
-			a.Fail(api.NoneIn(a.ContainsAny.Values(), a.name))
+			a.Fail(api.NoneIn(vals, a.name))
 			res = false
 		}
 	}
 	if a.ContainsNone != nil {
-		for _, find := range a.ContainsNone.Values() {
+		vals := a.ContainsNone.Values()
+		vals = lo.Map(vals, func(val string, _ int) string {
+			return a.vars.Replace(ctx, val)
+		})
+		for _, find := range vals {
 			if strings.Contains(contents, find) {
 				a.Fail(api.In(find, a.name))
 				res = false
@@ -114,6 +127,7 @@ func (a *pipeAssertions) OK(ctx context.Context) bool {
 
 // assertions contains all assertions made for the exec test
 type assertions struct {
+	vars Variables
 	// failures contains the set of error messages for failed assertions
 	failures []error
 	// expExitCode contains the expected exit code
@@ -162,11 +176,13 @@ func (a *assertions) OK(ctx context.Context) bool {
 // spec assertions
 func newAssertions(
 	e *Expect,
+	vars Variables,
 	exitCode int,
 	outPipe *bytes.Buffer,
 	errPipe *bytes.Buffer,
 ) api.Assertions {
 	a := &assertions{
+		vars:        vars,
 		failures:    []error{},
 		expExitCode: exitCode,
 		exitCode:    exitCode,
@@ -175,6 +191,7 @@ func newAssertions(
 		if e.Out != nil {
 			a.expOutPipe = &pipeAssertions{
 				PipeExpect: *e.Out,
+				vars:       vars,
 				name:       "stdout",
 				pipe:       outPipe,
 			}
@@ -182,6 +199,7 @@ func newAssertions(
 		if e.Err != nil {
 			a.expErrPipe = &pipeAssertions{
 				PipeExpect: *e.Err,
+				vars:       vars,
 				name:       "stderr",
 				pipe:       errPipe,
 			}

--- a/plugin/exec/eval_test.go
+++ b/plugin/exec/eval_test.go
@@ -395,3 +395,24 @@ func TestTimeoutWithWait(t *testing.T) {
 	err = s.Run(ctx, t)
 	require.Nil(err)
 }
+
+func TestVar(t *testing.T) {
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "var-save-restore.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	s, err := scenario.FromReader(
+		f,
+		scenario.WithPath(fp),
+	)
+	require.Nil(err)
+	require.NotNil(s)
+
+	t.Setenv("MY_ENVVAR", "meaning of life")
+
+	ctx := context.TODO()
+	err = s.Run(ctx, t)
+	require.Nil(err)
+}

--- a/plugin/exec/parse_test.go
+++ b/plugin/exec/parse_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnknownShell(t *testing.T) {
+func TestParseUnknownShell(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -34,7 +34,7 @@ func TestUnknownShell(t *testing.T) {
 	assert.Nil(s)
 }
 
-func TestSimpleCommand(t *testing.T) {
+func TestParseSimpleCommand(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -59,6 +59,51 @@ func TestSimpleCommand(t *testing.T) {
 			},
 			Action: gdtexec.Action{
 				Exec: "ls",
+			},
+		},
+	}
+	assert.Equal(expTests, s.Tests)
+}
+
+func TestParseVar(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "parse-var.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	s, err := scenario.FromReader(
+		f,
+		scenario.WithPath(fp),
+	)
+	assert.Nil(err)
+	assert.NotNil(s)
+
+	assert.IsType(&scenario.Scenario{}, s)
+	expTests := []api.Evaluable{
+		&gdtexec.Spec{
+			Spec: api.Spec{
+				Plugin:   gdtexec.PluginRef,
+				Index:    0,
+				Defaults: &api.Defaults{},
+			},
+			Action: gdtexec.Action{
+				Exec: "echo 42",
+			},
+			Var: gdtexec.Variables{
+				"VAR_STDOUT": gdtexec.VarEntry{
+					From: "stdout",
+				},
+				"VAR_STDERR": gdtexec.VarEntry{
+					From: "stderr",
+				},
+				"VAR_RC": gdtexec.VarEntry{
+					From: "returncode",
+				},
+				"MY_ENVVAR": gdtexec.VarEntry{
+					From: "MY_ENVVAR",
+				},
 			},
 		},
 	}

--- a/plugin/exec/spec.go
+++ b/plugin/exec/spec.go
@@ -17,6 +17,10 @@ type Spec struct {
 	Assert *Expect `yaml:"assert,omitempty"`
 	// On is an object containing actions to take upon certain conditions.
 	On *On `yaml:"on,omitempty"`
+	// Var allows the test author to save arbitrary data to the test scenario,
+	// facilitating the passing of variables between test specs potentially
+	// provided by different gdt Plugins.
+	Var Variables `yaml:"var,omitempty"`
 }
 
 func (s *Spec) SetBase(b api.Spec) {

--- a/plugin/exec/testdata/parse-var.yaml
+++ b/plugin/exec/testdata/parse-var.yaml
@@ -1,0 +1,10 @@
+name: parse-var
+description: parsing variable save/restore functionality
+tests:
+  - exec: echo 42
+    var-stdout: VAR_STDOUT
+    var-stderr: VAR_STDERR
+    var-rc: VAR_RC
+    var:
+      MY_ENVVAR:
+        from: MY_ENVVAR

--- a/plugin/exec/testdata/var-save-restore.yaml
+++ b/plugin/exec/testdata/var-save-restore.yaml
@@ -1,0 +1,21 @@
+name: var-save-restore
+description: a scenario that tests variable save/restore across multiple test specs
+tests:
+  - exec: echo 42
+    var-stdout: VAR_STDOUT
+
+  - exec: echo $$VAR_STDOUT
+    var-rc: VAR_RC
+    assert:
+      out:
+        is: 42
+
+  - exec: echo $$VAR_RC
+    assert:
+      out:
+        is: 0
+
+  - exec: echo 42
+    assert:
+      out:
+        is: $$VAR_STDOUT

--- a/plugin/exec/var.go
+++ b/plugin/exec/var.go
@@ -1,0 +1,64 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package exec
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	gdtcontext "github.com/gdt-dev/gdt/context"
+)
+
+const (
+	varFromStdout = "stdout"
+	varFromStderr = "stderr"
+	varFromRC     = "returncode"
+)
+
+type VarEntry struct {
+	// From is a string that indicates where the value of the variable will be
+	// sourced from. `stdout`, `stderr` and `returncode` indicate to source the
+	// value of the variable from the output buffer for stdout, stderr or the
+	// returncode value. All other strings indicate the value of the variable
+	// should be sourced from an envvar of the same name.
+	From string `yaml:"from"`
+}
+
+// Variables allows the test author to save arbitrary data to the test scenario,
+// facilitating the passing of variables between test specs potentially
+// provided by different gdt Plugins.
+type Variables map[string]VarEntry
+
+// Replace replaces all occurrences of any of the variables in the supplied
+// string with their stored variable values
+func (v Variables) Replace(
+	ctx context.Context,
+	subject string,
+) string {
+	data := gdtcontext.PriorRun(ctx)
+	for dataKey, dataVal := range data {
+		var dataValStr string
+		switch dataVal := dataVal.(type) {
+		case string:
+			dataValStr = dataVal
+		case []byte:
+			dataValStr = string(dataVal)
+		case int, uint, int8, int16, int32, int64:
+			dataValStr = strconv.Itoa(dataVal.(int))
+		case float32, float64:
+			dataValStr = strconv.FormatFloat(dataVal.(float64), 'f', -1, 64)
+		default:
+			continue
+		}
+		subject = strings.ReplaceAll(
+			subject,
+			fmt.Sprintf("$%s", dataKey),
+			dataValStr,
+		)
+	}
+	return subject
+}


### PR DESCRIPTION
Adds support for defining variables in an exec plugin test spec and referring to the variable in subsequent test specs.

A `gdt` test scenario is comprised of a list of test specs. These test specs are executed in sequential order. If you want to have one test spec be able to use some output or value calculated or asserted in a previous step, you can use the `gdt` variable system.

Here's an test scenario that shows how to define variables in a test spec and how to use those variables in later test specs.

file: `plugin/exec/testdata/var-save-restore.yaml`:

```yaml
name: var-save-restore
description: a scenario that tests variable save/restore across multiple test specs
tests:
  - exec: echo 42
    var-stdout: VAR_STDOUT

  - exec: echo $$VAR_STDOUT
    var-rc: VAR_RC
    assert:
      out:
        is: 42

  - exec: echo $$VAR_RC
    assert:
      out:
        is: 0

  - exec: echo 42
    assert:
      out:
        is: $$VAR_STDOUT
```

In the first test spec, we specify that we want to store the value of the `stdout` stream in a variable called `VAR_STDOUT`:

```yaml
  - exec: echo 42
    var-stdout: VAR_STDOUT
```

In the second test spec, we refer to the `VAR_STDOUT` variable using the double-dollar-sign notation in the `exec` field and also specify a `VAR_RC` variable to contain the value of the return/exitcode from the executed statement (`echo 42`):

```yaml
  - exec: echo $$VAR_STDOUT
    var-rc: VAR_RC
    assert:
      out:
        is: 42
```

> **NOTE**: We use the double-dollar-sign notation because by default, `gdt`
> replaces all single-dollar-sign notations with environment variables *BEFORE*
> executing the test specs in a test scenario. Using the double-dollar-sign
> notation means that environment variable substitution does not impact the
> referencing of `gdt` variables referenced in a test spec.

In the third test spec, we simply echo out the value of that `VAR_RC` variable and assert that the stdout stream contains the string "0" (since `echo 42` returns 0.):

```yaml
  - exec: echo $$VAR_RC
    assert:
      out:
        is: 0
```

Finally, in the fourth step, we demonstrate that we can refer to the `VAR_STDOUT` variable defined in the very first test spec from the `assert.out.is` field. This shows the flexibility of the `gdt` variable system. You can define variables using a simple declarative syntax and then refer to the value of those variables using the double-dollar-sign notation in any subsequent test spec.

Issue #51