### PR TITLE
uplift to core@1.10.4 and kube@#1.10.3

### DIFF
--- a/cmd/gdt/go.mod
+++ b/cmd/gdt/go.mod
@@ -3,9 +3,9 @@ module github.com/gdt-dev/gdt/cmd/gdt
 go 1.24.3
 
 require (
-	github.com/gdt-dev/core v1.10.2
+	github.com/gdt-dev/core v1.10.4
 	github.com/gdt-dev/http v1.10.0
-	github.com/gdt-dev/kube v1.10.2
+	github.com/gdt-dev/kube v1.10.3
 	github.com/samber/lo v1.51.0
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10

--- a/cmd/gdt/go.sum
+++ b/cmd/gdt/go.sum
@@ -19,12 +19,12 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gdt-dev/core v1.10.2 h1:85F88MI5NWXp6+HycPjfjLXteH4nNV9i++uS1NALYNs=
-github.com/gdt-dev/core v1.10.2/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
+github.com/gdt-dev/core v1.10.4 h1:o9F8X8n0pqYijZ1/JO7MNAPfIVFwTYctmgNv8Fy2F9w=
+github.com/gdt-dev/core v1.10.4/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
 github.com/gdt-dev/http v1.10.0 h1:rYeUEy3CmuW/idMC3NxOomxguSmfKBvn0uLadZSwrBM=
 github.com/gdt-dev/http v1.10.0/go.mod h1:pWFKveQS1WHgDbq/lyIew9mkdelZIJZnOnIrgByEAvU=
-github.com/gdt-dev/kube v1.10.2 h1:d9hHOQddKbVAcPG3x91898DKiwlF4+XgrKznQQjYmqE=
-github.com/gdt-dev/kube v1.10.2/go.mod h1:9F98P/wUEMHYjfvBXgomMFoKj6m2N1+Die7cDLRVj+s=
+github.com/gdt-dev/kube v1.10.3 h1:Od6bkBZBI6AB6m0MxRlyCvwOiibsBmN7J/r5e0UVIdI=
+github.com/gdt-dev/kube v1.10.3/go.mod h1:n5AmMgo9J3AymtQs90VRu5YmfHdkvJxGfsUC07HQbQY=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gdt-dev/gdt
 
 go 1.24.3
 
-require github.com/gdt-dev/core v1.10.2
+require github.com/gdt-dev/core v1.10.4
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gdt-dev/core v1.10.2 h1:85F88MI5NWXp6+HycPjfjLXteH4nNV9i++uS1NALYNs=
-github.com/gdt-dev/core v1.10.2/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
+github.com/gdt-dev/core v1.10.4 h1:o9F8X8n0pqYijZ1/JO7MNAPfIVFwTYctmgNv8Fy2F9w=
+github.com/gdt-dev/core v1.10.4/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=


### PR DESCRIPTION
Fixes issue #66

```
·> cat ../core/plugin/exec/testdata/pass-on-fail-issue-65.yaml
tests:
 - name: test 1
   exec: echo 42
   assert:
     out:
       is: 24
 - name: test 2
   exec: echo "meaning of life"
   assert:
     out:
       contains: life

·> ./bin/gdt run ../core/plugin/exec/testdata/pass-on-fail-issue-65.yaml -v
=== RUN: ../core/plugin/exec/testdata/pass-on-fail-issue-65.yaml
--- FAIL: pass-on-fail-issue-65.yaml/test 1 (631.56µs)
    assertion failed: not in: expected stdout to contain 24
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                    DETAIL
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
[gdt] [pass-on-fail-issue-65.yaml/0:test 1] using timeout of 10s [plugin default]
[gdt] [pass-on-fail-issue-65.yaml/0:test 1] exec: echo [42]
[gdt] [pass-on-fail-issue-65.yaml/0:test 1] exec: stdout: 42
[gdt] [pass-on-fail-issue-65.yaml/0:test 1] spec/run: single-shot (no retries) ok: false
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
--- PASS: pass-on-fail-issue-65.yaml/test 2 (660.94µs)
FAIL	../core/plugin/exec/testdata/pass-on-fail-issue-65.yaml	1.2925ms
FAIL
```