### PR TITLE
enable support for JUnit/XUnit and JSON output

### DIFF
--- a/cmd/gdt/go.mod
+++ b/cmd/gdt/go.mod
@@ -3,7 +3,7 @@ module github.com/gdt-dev/gdt/cmd/gdt
 go 1.24.3
 
 require (
-	github.com/gdt-dev/core v1.12.0
+	github.com/gdt-dev/core v1.12.1
 	github.com/gdt-dev/http v1.11.0
 	github.com/gdt-dev/kube v1.11.0
 	github.com/samber/lo v1.51.0

--- a/cmd/gdt/go.sum
+++ b/cmd/gdt/go.sum
@@ -21,8 +21,8 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gdt-dev/core v1.12.0 h1:/Apz/cwEWhkT3jmexIDQmnVbbzzC6iwmgunfpPMyMx0=
-github.com/gdt-dev/core v1.12.0/go.mod h1:hGXsI+PXavvLkm0BQIYKZ1O3yRw86m/VD2xFiNwFR/Y=
+github.com/gdt-dev/core v1.12.1 h1:nW6/+aY42ZpQZaWbKwDQyYt10XXwZj0scV5ca3NMAnY=
+github.com/gdt-dev/core v1.12.1/go.mod h1:hGXsI+PXavvLkm0BQIYKZ1O3yRw86m/VD2xFiNwFR/Y=
 github.com/gdt-dev/http v1.11.0 h1:xEkdLLXbI3wwd61RDcjE2lQdsQ+R0y7ROlbjbBDAe/o=
 github.com/gdt-dev/http v1.11.0/go.mod h1:SHsSUi6+OybfQCY7kSaLc9LaKovXokVjVKaAzVkZvFE=
 github.com/gdt-dev/kube v1.11.0 h1:o6/Dq5ho6LJP1FPxili1jvYuRl+D6HNhzCyXlfmQOpg=

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gdt-dev/gdt
 
 go 1.24.3
 
-require github.com/gdt-dev/core v1.12.0
+require github.com/gdt-dev/core v1.12.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gdt-dev/core v1.12.0 h1:/Apz/cwEWhkT3jmexIDQmnVbbzzC6iwmgunfpPMyMx0=
-github.com/gdt-dev/core v1.12.0/go.mod h1:hGXsI+PXavvLkm0BQIYKZ1O3yRw86m/VD2xFiNwFR/Y=
+github.com/gdt-dev/core v1.12.1 h1:nW6/+aY42ZpQZaWbKwDQyYt10XXwZj0scV5ca3NMAnY=
+github.com/gdt-dev/core v1.12.1/go.mod h1:hGXsI+PXavvLkm0BQIYKZ1O3yRw86m/VD2xFiNwFR/Y=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=


### PR DESCRIPTION
Adds a `-o|--output` CLI option to the `gdt` CLI tool that triggers output in either JUnit/XUnit:

```
$ gdt run --debug ../../chkk-io/readiness-checks/guided/addons/cert-manager/api.readiness-after14.yaml -oxunit
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="api.readiness-after14.yaml" time="2.885919111s" failures="0" errors="0" tests="6" timestamp="2025-12-09T14:39:15.621382231-05:00">
    <properties name="path" value="../../chkk-io/readiness-checks/guided/addons/cert-manager/api.readiness-after14.yaml"></properties>
    <testcases name="Cert Manager API Readiness Checks/ensure certificaterequest CRD installed" time="12.454946ms" status="ok">
      <system-out><![CDATA[[gdt] [Cert Manager API Readiness Checks/0:ensure certificaterequest CRD installed] using retry (exponential: true) [plugin default]
[gdt] [Cert Manager API Readiness Checks/0:ensure certificaterequest CRD installed] using timeout of 5s [plugin default]
[gdt] [Cert Manager API Readiness Checks/0:ensure certificaterequest CRD installed] kube.get: customresourcedefinitions/certificaterequests.cert-manager.io (non-namespaced resource)
[gdt] [Cert Manager API Readiness Checks/0:ensure certificaterequest CRD installed] spec/run: attempt 1 after 952ns ok: true
]]></system-out>
    </testcases>
    <testcases name="Cert Manager API Readiness Checks/ensure issuers CRD installed" time="9.552465ms" status="ok">
      <system-out><![CDATA[[gdt] [Cert Manager API Readiness Checks/1:ensure issuers CRD installed] using retry (exponential: true) [plugin default]
[gdt] [Cert Manager API Readiness Checks/1:ensure issuers CRD installed] using timeout of 5s [plugin default]
[gdt] [Cert Manager API Readiness Checks/1:ensure issuers CRD installed] kube.get: customresourcedefinitions/issuers.cert-manager.io (non-namespaced resource)
[gdt] [Cert Manager API Readiness Checks/1:ensure issuers CRD installed] spec/run: attempt 1 after 1.178µs ok: true
]]></system-out>
    </testcases>
    <testcases name="Cert Manager API Readiness Checks/cmctl check api" time="42.481764ms" status="ok">
      <system-out><![CDATA[[gdt] [Cert Manager API Readiness Checks/2:cmctl check api] using timeout of 10s [plugin default]
[gdt] [Cert Manager API Readiness Checks/2:cmctl check api] exec: cmctl [check api]
[gdt] [Cert Manager API Readiness Checks/2:cmctl check api] exec: stdout: The cert-manager API is ready
[gdt] [Cert Manager API Readiness Checks/2:cmctl check api] spec/run: single-shot (no retries) ok: true
]]></system-out>
    </testcases>
    <testcases name="Cert Manager API Readiness Checks/get webhook pod name" time="6.448293ms" status="ok">
      <system-out><![CDATA[[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] using retry (exponential: true) [plugin default]
[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] using timeout of 5s [plugin default]
[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] kube.get: pods (labels: app.kubernetes.io/component=webhook) (ns: cert-manager)
[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] save.vars: WEBHOOK_POD_NAME -> cert-manager-webhook-65ccc474d9-sjrkv
[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] spec/run: attempt 1 after 509ns ok: true
]]></system-out>
    </testcases>
    <testcases name="Cert Manager API Readiness Checks/verify webhook pod ready" time="7.535129ms" status="ok">
      <system-out><![CDATA[[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] using retry (exponential: true) [plugin default]
[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] using timeout of 5s [plugin default]
[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] kube.get: replaced name: $WEBHOOK_POD_NAME -> cert-manager-webhook-65ccc474d9-sjrkv
[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] kube.get: pods/cert-manager-webhook-65ccc474d9-sjrkv (ns: cert-manager)
[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] save.vars: WEBHOOK_POD_IP -> 10.244.0.5
[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] spec/run: attempt 1 after 798ns ok: true
]]></system-out>
    </testcases>
    <testcases name="Cert Manager API Readiness Checks/curl pod from test container" time="2.807446514s" status="ok">
      <system-out><![CDATA[[gdt] [Cert Manager API Readiness Checks/5:curl pod from test container] using timeout of 300s
[gdt] [Cert Manager API Readiness Checks/5:curl pod from test container] exec: replaced arg: http://$WEBHOOK_POD_IP:6080/healthz -> http://10.244.0.5:6080/healthz
[gdt] [Cert Manager API Readiness Checks/5:curl pod from test container] exec: kubectl [run chkk-cert-manager-api-check --image=curlimages/curl --rm -i --restart=Never --quiet --command -- curl -s http://10.244.0.5:6080/healthz]
[gdt] [Cert Manager API Readiness Checks/5:curl pod from test container] spec/run: single-shot (no retries) ok: true
]]></system-out>
    </testcases>
  </testsuite>
</testsuites>
```

or JSON output format:

```
$ gdt run ../../chkk-io/readiness-checks/guided/addons/cert-manager/api.readiness-after14.yaml -ojson
{
  "testsuites": [
    {
      "name": "api.readiness-after14.yaml",
      "time": "2.635655869s",
      "failures": 0,
      "errors": 0,
      "tests": 6,
      "timestamp": "2025-12-09T14:39:36.708906197-05:00",
      "properties": [
        {
          "name": "path",
          "value": "../../chkk-io/readiness-checks/guided/addons/cert-manager/api.readiness-after14.yaml"
        }
      ],
      "testcases": [
        {
          "name": "Cert Manager API Readiness Checks/ensure certificaterequest CRD installed",
          "time": "24.768068ms",
          "status": "ok",
          "assertions": 0,
          "system-out": {
            "Text": "[gdt] [Cert Manager API Readiness Checks/0:ensure certificaterequest CRD installed] using retry (exponential: true) [plugin default]\n[gdt] [Cert Manager API Readiness Checks/0:ensure certificaterequest CRD installed] using timeout of 5s [plugin default]\n[gdt] [Cert Manager API Readiness Checks/0:ensure certificaterequest CRD installed] kube.get: customresourcedefinitions/certificaterequests.cert-manager.io (non-namespaced resource)\n[gdt] [Cert Manager API Readiness Checks/0:ensure certificaterequest CRD installed] spec/run: attempt 1 after 831ns ok: true\n"
          }
        },
        {
          "name": "Cert Manager API Readiness Checks/ensure issuers CRD installed",
          "time": "35.025181ms",
          "status": "ok",
          "assertions": 0,
          "system-out": {
            "Text": "[gdt] [Cert Manager API Readiness Checks/1:ensure issuers CRD installed] using retry (exponential: true) [plugin default]\n[gdt] [Cert Manager API Readiness Checks/1:ensure issuers CRD installed] using timeout of 5s [plugin default]\n[gdt] [Cert Manager API Readiness Checks/1:ensure issuers CRD installed] kube.get: customresourcedefinitions/issuers.cert-manager.io (non-namespaced resource)\n[gdt] [Cert Manager API Readiness Checks/1:ensure issuers CRD installed] spec/run: attempt 1 after 1.202µs ok: true\n"
          }
        },
        {
          "name": "Cert Manager API Readiness Checks/cmctl check api",
          "time": "45.083687ms",
          "status": "ok",
          "assertions": 0,
          "system-out": {
            "Text": "[gdt] [Cert Manager API Readiness Checks/2:cmctl check api] using timeout of 10s [plugin default]\n[gdt] [Cert Manager API Readiness Checks/2:cmctl check api] exec: cmctl [check api]\n[gdt] [Cert Manager API Readiness Checks/2:cmctl check api] exec: stdout: The cert-manager API is ready\n[gdt] [Cert Manager API Readiness Checks/2:cmctl check api] spec/run: single-shot (no retries) ok: true\n"
          }
        },
        {
          "name": "Cert Manager API Readiness Checks/get webhook pod name",
          "time": "7.492367ms",
          "status": "ok",
          "assertions": 0,
          "system-out": {
            "Text": "[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] using retry (exponential: true) [plugin default]\n[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] using timeout of 5s [plugin default]\n[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] kube.get: pods (labels: app.kubernetes.io/component=webhook) (ns: cert-manager)\n[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] save.vars: WEBHOOK_POD_NAME -\u003e cert-manager-webhook-65ccc474d9-sjrkv\n[gdt] [Cert Manager API Readiness Checks/3:get webhook pod name] spec/run: attempt 1 after 685ns ok: true\n"
          }
        },
        {
          "name": "Cert Manager API Readiness Checks/verify webhook pod ready",
          "time": "10.682972ms",
          "status": "ok",
          "assertions": 0,
          "system-out": {
            "Text": "[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] using retry (exponential: true) [plugin default]\n[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] using timeout of 5s [plugin default]\n[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] kube.get: replaced name: $WEBHOOK_POD_NAME -\u003e cert-manager-webhook-65ccc474d9-sjrkv\n[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] kube.get: pods/cert-manager-webhook-65ccc474d9-sjrkv (ns: cert-manager)\n[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] save.vars: WEBHOOK_POD_IP -\u003e 10.244.0.5\n[gdt] [Cert Manager API Readiness Checks/4:verify webhook pod ready] spec/run: attempt 1 after 522ns ok: true\n"
          }
        },
        {
          "name": "Cert Manager API Readiness Checks/curl pod from test container",
          "time": "2.512603594s",
          "status": "ok",
          "assertions": 0,
          "system-out": {
            "Text": "[gdt] [Cert Manager API Readiness Checks/5:curl pod from test container] using timeout of 300s\n[gdt] [Cert Manager API Readiness Checks/5:curl pod from test container] exec: replaced arg: http://$WEBHOOK_POD_IP:6080/healthz -\u003e http://10.244.0.5:6080/healthz\n[gdt] [Cert Manager API Readiness Checks/5:curl pod from test container] exec: kubectl [run chkk-cert-manager-api-check --image=curlimages/curl --rm -i --restart=Never --quiet --command -- curl -s http://10.244.0.5:6080/healthz]\n[gdt] [Cert Manager API Readiness Checks/5:curl pod from test container] spec/run: single-shot (no retries) ok: true\n"
          }
        }
      ]
    }
  ]
}

```

Issue gdt-dev/gdt#69